### PR TITLE
Save checkpoint into hf/titan format

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -218,7 +218,7 @@ class ForgeSFTRecipe(ForgeEngine):
                         self.current_step
                     ),
                     async_mode=self.checkpointer.async_mode,
-                    to_hf=False,
+                    to_hf=True,
                 )
 
     def cleanup(self) -> None:


### PR DESCRIPTION
This enables checkpoint saving to the configured checkpoint directory. 

Checkpoints are saved with filenames in the format `step-xx` to the folder specified in the config file checkpoint.folder . 

It supports both `to_hf=True` and `to_hf=False`

 The functionality has been tested for saving and loading checkpoints in both formats.