### PR TITLE
remove src from project.scripts path, small readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pip install uv
 git clone https://github.com/pytorch-labs/forge
 cd forge
 uv sync
+
+# Or for dev install:
+uv sync --all-extras
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
 ]
 
 [project.scripts]
-forge = "src.forge.cli.forge:main"
+forge = "forge.cli.forge:main"
 
 [tool.setuptools.dynamic]
 version = {file = "assets/version.txt"}


### PR DESCRIPTION
Previously running e.g. `uv run forge run ...` resulted in

```
  File "/home/ebs/forge/.venv/bin/forge", line 4, in <module>
    from src.forge.cli.forge import main
ModuleNotFoundError: No module named 'src'
```

This change fixes the scripts config to remove the leading `src`. After the change:

```
uv run forge run --nproc_per_node 4 apps/sft/main.py --config apps/sft/llama3_8b.yaml model.name=deepseek_v3 model.flavor=16B model.tokenizer_path=/tmp/deepseek-moe-16b-chat checkpoint.folder=/tmp/deepseek-moe-16b-chat
...
(some monarch issue)
```
