### PR TITLE
Remove torch/monarch from dep to enable MAST install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ dependencies = [
     # PyTorch
     "torchdata>=0.8.0",
     "torchtitan",
-    "torch",
-    "torchmonarch-nightly==2025.8.1",
+    # Temporarily comment out in favor of enabling MAST path
+    #"torch",
+    #"torchmonarch-nightly==2025.8.1",
     # vLLM
     # TODO: pin specific vllm version
     #"vllm==0.10.0",


### PR DESCRIPTION
There are a few ways to get a dev workflow working, with MAST being one of the most updated ones.
This PR consciously break OSS install support in favor of enabling the MAST flow.

See `forge env setup: MAST enviroment` for more details