### PR TITLE
drop torchstore dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "tokenizers",
     # Miscellaneous
     "omegaconf",
-    "torchstore",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This will cause errors on any installs without uv 

Before:

```
pip install -e .
...
ERROR: Could not find a version that satisfies the requirement torchstore (from forge) (from versions: none)
ERROR: No matching distribution found for torchstore
```

After:

```
pip install -e .
...
Successfully installed forge-0.0.0
```