### PR TITLE
make dataset configurable and add validation loop

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -91,7 +91,7 @@ class ForgeSFTRecipe(ForgeEngine):
         # self.profiler = self.setup_profiler(self.train_config.profiler_config)
         # self.logger = self.setup_logger(self.train_config.logger_config)
 
-    def setup_data(self, dataset_config, batch_size, infinite=True):
+    def setup_data(self, dataset_config, batch_size):
         tokenizer = HuggingFaceModelTokenizer(
             tokenizer_json_path=os.path.join(
                 self.job_config.model.hf_assets_path, "tokenizer.json"
@@ -109,7 +109,6 @@ class ForgeSFTRecipe(ForgeEngine):
             message_transform=AlpacaToMessages(),
             path=dataset_config.path,
             split=dataset_config.split,
-            infinite=infinite,
         )
         packer = TextPacker(padding_idx=0)
         dataset = PackedDataset(

--- a/src/forge/data/datasets/hf_dataset.py
+++ b/src/forge/data/datasets/hf_dataset.py
@@ -75,7 +75,6 @@ class HfIterableDataset(InfiniteTuneIterableDataset):
         dataset_name: Optional[str] = None,
         filter_fn: Optional[Callable] = None,
         filter_kwargs: Optional[dict[str, Any]] = None,
-        infinite: bool = True,
         **load_dataset_kwargs,
     ):
         # Store configuration
@@ -114,7 +113,6 @@ class HfIterableDataset(InfiniteTuneIterableDataset):
         self._setup_hf_dataset(
             load_dataset_kwargs, num_shards_per_rank, filter_fn, filter_kwargs
         )
-        self.infinite = infinite
 
     @property
     def info(self) -> DatasetInfo:
@@ -254,9 +252,6 @@ class HfIterableDataset(InfiniteTuneIterableDataset):
 
                     samples_yielded += 1
                     yield sample
-
-                if not self.infinite:
-                    break
 
             except StopIteration:
                 # Expected when dataset is exhausted

--- a/src/forge/data/datasets/sft_dataset.py
+++ b/src/forge/data/datasets/sft_dataset.py
@@ -163,7 +163,6 @@ def sft_iterable_dataset(
     dataset_name: Optional[str] = None,
     filter_fn: Optional[Callable] = None,
     filter_kwargs: Optional[dict[str, Any]] = None,
-    infinite: bool = True,
     **load_dataset_kwargs: dict[str, Any],
 ) -> HfIterableDataset:
     """
@@ -208,6 +207,5 @@ def sft_iterable_dataset(
         dataset_name=dataset_name,
         filter_fn=filter_fn,
         filter_kwargs=filter_kwargs,
-        infinite=infinite,
         **load_dataset_kwargs,
     )


### PR DESCRIPTION
- Make dataset path and split configurable
- Add validation dataloader
- Add validation loop

Added `dataset_val` and `validation` sections in the config file:
```
validation:
  local_batch_size: 1
  freq: -1  # Change to a positive number to enable validation
  steps: 200  # Max steps to run validation. Validation disabled if negative.

dataset_val:
  path: yahma/alpaca-cleaned
  split: train[95%:]

```

**Test**:

```
uv run forge run --nproc_per_node 2 apps/sft/main.py --config apps/sft/llama3_8b.yaml
```

The validation freq (`freq`) is set to 2 (run validation every two steps):

```
1|Loss: 1.0664817094802856:   0%|          | 2/1000 [00:06<57:53,  3.48s/it]
Validation loss: 1.311207890510559
Running validation Loss: 1.3039: : 200it [00:24,  8.28it/s]
Validation loss: 1.311207890510559
3|Loss: 1.2771787643432617:   0%|          | 4/1000 [00:31<2:15:20,  8.15s/it]
Validation loss: 1.3083338737487793
Running validation Loss: 1.2985: : 200it [00:24,  8.25it/s]
Validation loss: 1.3083338737487793
5|Loss: 1.3110204935073853:   1%|          | 6/1000 [00:57<2:37:35,  9.51s/it]
Validation loss: 1.2877949476242065
Running validation Loss: 1.2748: : 199it [00:24,  8.32it/s]
Validation loss: 1.2877949476242065
7|Loss: 1.3947221040725708:   1%|          | 8/1000 [01:22<2:46:21, 10.06s/it]
Validation loss: 1.274566411972046
Running validation Loss: 1.2768: : 200it [00:24,  8.12it/s]
Validation loss: 1.274566411972046
9|Loss: 1.1953884363174438:   1%|          | 10/1000 [01:48<2:50:45, 10.35s/it]
Validation loss: 1.2020115852355957
Running validation Loss: 1.1951: : 200it [00:24,  8.17it/s]
Validation loss: 1.2020115852355957
11|Loss: 1.2392996549606323:   1%|          | 12/1000 [02:13<2:53:13, 10.52s/it]
Validation loss: 1.1668553352355957
Running validation Loss: 1.1603: : 200it [00:24,  8.12it/s]
Validation loss: 1.1668553352355957
13|Loss: 1.041933536529541:   1%|▏         | 14/1000 [02:39<2:54:35, 10.62s/it]]
Validation loss: 1.0708351135253906
Running validation Loss: 1.0622: : 200it [00:24,  8.22it/s]
Validation loss: 1.0708351135253906
15|Loss: 1.0107098817825317:   2%|▏         | 16/1000 [03:05<2:54:47, 10.66s/it]
```

Tested steps = 10 and 200 (exhaust the dataset).