### PR TITLE
Adds name checking in actor spawning

### DIFF
--- a/src/forge/controller/service.py
+++ b/src/forge/controller/service.py
@@ -1068,8 +1068,13 @@ class Service:
             replica: Replica,
         ) -> Callable[[ProcMesh], Coroutine[Any, Any, None]]:
             async def inner_hook(proc_mesh: ProcMesh) -> None:
+                if "name" in self._actor_kwargs:
+                    actor_name = self._actor_kwargs.pop("name")
+                else:
+                    actor_name = self._actor_def.__name__
+                # TODO - expand support so name can stick within kwargs
                 actor = await proc_mesh.spawn(
-                    self._actor_def.__name__,
+                    actor_name,
                     self._actor_def,
                     *self._actor_args,
                     **self._actor_kwargs,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -490,7 +490,9 @@ async def test_concurrent_operations():
     cfg = ServiceConfig(
         procs_per_replica=1, min_replicas=2, max_replicas=2, default_replicas=2
     )
-    service = await spawn_service(service_cfg=cfg, actor_def=Counter, v=0)
+    service = await spawn_service(
+        service_cfg=cfg, actor_def=Counter, name="counter", v=0
+    )
 
     try:
         # Mix of session and sessionless calls


### PR DESCRIPTION
Allows `service = await spawn_service(service_cfg, actor_def=Counter, name="counter", v=0)`
