### PR TITLE
Add Grouped Rollout to Policy

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -390,7 +390,7 @@ if __name__ == "__main__":
         "enforce_eager": True,
         "resources": 2,
     }
-    asyncio.run(_test(config))
+    # asyncio.run(_test(config))
     # asyncio.run(_test(config, guided_decoding=True))
     # asyncio.run(_test(config, num_samples=2))
     # asyncio.run(_test(config, guided_decoding=True, num_samples=3))


### PR DESCRIPTION
For Grouped Rollouts (n > 1), a `ParentRequest` is introduced to aggregate and track the fanned out children.

`policy_router.generate` will return a list of `CompletionOutputs` when all the children of the ParentRequest complete (this is maintained internally in vllm's [OutputProcessor](https://github.com/vllm-project/vllm/blob/21dce80ea96bcf033d159c0f952fb274567b315c/vllm/v1/engine/output_processor.py#L274))

---
Followups 
- Tests should be moved into CI tests
- Customization will be piped up to configs

<img width="898" height="383" alt="image" src="https://github.com/user-attachments/assets/3eba685e-f087-496e-b14c-c789977a0737" />
