### PR TITLE
[ez] zero grad every step

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -205,8 +205,8 @@ class ForgeSFTRecipe(ForgeEngine):
         self.pbar.set_description(f"{self.current_step}|Loss: {loss}")
 
         self.optimizers.step()
-        self.lr_schedulers.step()
         self.optimizers.zero_grad()
+        self.lr_schedulers.step()
 
     def train(self) -> None:
         dataloader = iter(self.train_dataloader)


### PR DESCRIPTION
Fixing a dumb bug where we weren't zeroing grad on optimizers after each step. Thanks to @pbontrager for pointing it out