### PR TITLE
fix Error in episode x: 'tuple' object has no attribute '_values' in apps/toy_rl

### DIFF
--- a/apps/toy_rl/main.py
+++ b/apps/toy_rl/main.py
@@ -171,7 +171,7 @@ async def main():
             try:
                 print(f"🎮 Running episode {episode_count + 1}...")
                 results = await collectors.run_episode.call()
-                num_trajectories = sum([len(r._values) for r in results])
+                num_trajectories = len([r for r in results])
                 episode_count += 1
                 print(
                     f"✅ Episode {episode_count} completed! Generated {num_trajectories} trajectories."


### PR DESCRIPTION

Summary:
calling items() on ValueMesh yields a flattened iterable of Tuple[Point, Trajectory] now, probably due to monarch api change.

Test Plan:
python -m apps.toy_rl.main
