### PR TITLE
[fix] call init_attention_mask inside of training loop

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -30,6 +30,7 @@ from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.experiments.forge.engine import ForgeEngine
 from torchtitan.experiments.forge.job_config import ForgeJobConfig
+from torchtitan.models.attention import init_attention_mask
 from tqdm import tqdm
 
 
@@ -92,7 +93,7 @@ class ForgeSFTRecipe(ForgeEngine):
         # self.logger = self.setup_logger(self.train_config.logger_config)
 
     def setup_data(self, dataset_config, batch_size):
-        tokenizer = HuggingFaceModelTokenizer(
+        self.tokenizer = HuggingFaceModelTokenizer(
             tokenizer_json_path=os.path.join(
                 self.job_config.model.hf_assets_path, "tokenizer.json"
             ),
@@ -105,7 +106,7 @@ class ForgeSFTRecipe(ForgeEngine):
         )
 
         dataset = sft_iterable_dataset(
-            model_transform=tokenizer,
+            model_transform=self.tokenizer,
             message_transform=AlpacaToMessages(),
             path=dataset_config.path,
             split=dataset_config.split,
@@ -142,6 +143,13 @@ class ForgeSFTRecipe(ForgeEngine):
         # apply context parallelism if cp is enabled
         # ensure CP handles the separate freqs_cis buffer for each pp stage
         inputs = input_dict["tokens"]
+
+        if getattr(self.model_args, "use_flex_attn", False):
+            cp_mesh = (
+                parallel_dims.world_mesh["cp"] if parallel_dims.cp_enabled else None
+            )
+            init_attention_mask(inputs, self.tokenizer.base_tokenizer.eos_id, cp_mesh)
+
         optional_context_parallel_ctx = (
             dist_utils.create_context_parallel_ctx(
                 cp_mesh=parallel_dims.world_mesh["cp"],


### PR DESCRIPTION
After the changes in https://github.com/pytorch/torchtitan/pull/1616, we need to explicitly initialize the attention mask in our trainer code. 

Test plan: hacked Llama3 8B in my local titan code to enable flex as in [this config](https://github.com/pytorch/torchtitan/blob/e65ef30dec74e8e592191a1487e92256d27ecb2b/torchtitan/models/llama3/__init__.py#L40-L51). Then ran:

```
forge run --nproc_per_node 2 apps/sft/main.py --config apps/sft/llama3_8b.yaml
```

On main:

```
...
[rank0]:     output = self.sdpa(xq, xk, xv)
[rank0]:   File "/home/ebs/.fbpkg_conda_envs/forge-6f4168f/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/ebs/.fbpkg_conda_envs/forge-6f4168f/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/ebs/torchtitan/torchtitan/models/attention.py", line 88, in forward
[rank0]:     block_mask = FlexAttention.block_masks[self.mask_key]
[rank0]: KeyError: ('block_causal', None)
```

On this branch:

```
...
4|Loss: 12.06763744354248:   0%|▉                    | 5/1000 [00:08<23:58,  1.45s/it]
```