### PR TITLE
Fix infinite recursion when _service is not set

### DIFF
--- a/src/forge/controller/service/interface.py
+++ b/src/forge/controller/service/interface.py
@@ -179,7 +179,6 @@ class ServiceInterface:
 
     def __getattr__(self, name: str):
         """Forward all other attribute access to the underlying Service Actor."""
-        # No infinite recursion please
         try:
             _service = object.__getattribute__(self, "_service")
         except AttributeError:


### PR DESCRIPTION

Summary:
To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service, I must find _service. To find _service...
Stack overflow. Maybe I should look somewhere else.
