### PR TITLE
Add instruction to set export HF_HUB_DISABLE_XET=1 when running vllm app.

### DIFF
--- a/src/forge/actors/trainer.py
+++ b/src/forge/actors/trainer.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import asyncio
 import logging
 import math
 import os
@@ -13,14 +12,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
 
 import torch
-import torchtitan.experiments.forge.train_spec as forge_train_spec
-
-# from tqdm import tqdm
-
-
-from forge.controller import ForgeActor
 from monarch.actor import current_rank, current_size, endpoint
-from torchstore._state_dict_utils import push_state_dict
 from torchtitan.config.job_config import (
     ActivationCheckpoint,
     Checkpoint,
@@ -37,6 +29,8 @@ from torchtitan.config.job_config import (
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.experiments.forge.engine import ForgeEngine
 from torchtitan.experiments.forge.job_config import ForgeJobConfig
+
+from forge.controller import ForgeActor
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -191,18 +185,6 @@ class RLTrainer(ForgeActor):
         self.engine.lr_schedulers.step()
 
         self.current_step += 1
-
-        # save to torchstore. Hacking in to the Checkpointer's prepped state-dict for now.
-        # TODOs:
-        # 1. Figure out if there is a value in calling state_dict_adatpr.to_hf()
-        # 2. Checkpoint invokes state-dict flattening during dcp_save for [MODEL].
-        #    May need to replicate the same in this code path.
-        # 3. Integrate zero-overhead version of push_state_dict.
-        # 4. Figure out a way to notify the generator app that weights are ready. This beyond the initial integration success.
-        # 5. Unify CheckpointManager and TorchStore weights save control path.
-        push_state_dict(self._tstore, self.checkpointer.states, f"v{self.current_step}")
-        # if self.current_step % self.train_config.val_every_n_steps == 0:
-        #     self.validate()
         self.engine.checkpointer.save(
             curr_step=self.current_step,
             last_step=self.current_step == self.num_training_steps,


### PR DESCRIPTION
$Title. Otherwise following errors happen.


0] [0]     return hf_hub_download(
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
[0] [0]     return fn(*args, **kwargs)
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1010, in hf_hub_download
[0] [0]     return _hf_hub_download_to_cache_dir(
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1171, in _hf_hub_download_to_cache_dir
[0] [0]     _download_to_tmp_and_move(
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1723, in _download_to_tmp_and_move
[0] [0]     xet_get(
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 629, in xet_get
[0] [0]     download_files(
[0] [0] RuntimeError: Data processing error: CAS service error : ReqwestMiddleware Error: Request failed after 5 retries
[0] [0] Traceback (most recent call last):
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/monarch/_src/actor/actor_mesh.py", line 837, in handle
[0] [0]     result = await instrumented()
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/monarch/_src/actor/actor_mesh.py", line 834, in instrumented
[0] [0]     raise e
[0] [0]   File "/home/pradeepfdo/.conda/envs/forge/lib/python3.10/site-packages/monarch/_src/actor/actor_mesh.py", line 827, in instrumented
[0] [0]     result = await the_method(*args, **kwargs)
[0] [0]   File "/home/pradeepfdo/forge_fork/src/forge/actors/policy.py", line 380, in setup
[0] [0]     self.worker = self.setup_worker()
[0] [0]   File "/home/pradeepfdo/f