### PR TITLE
VLLM + torchstore integration test upgrade to match the new Policy APIs.

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -332,9 +332,9 @@ class Policy(PolicyInterface):
         return self.weights_version
 
     @endpoint
-    async def get_model_params(self) -> Dict[str, torch.Tensor]:
+    async def _get_model_params(self) -> Dict[str, torch.Tensor]:
         """Get the current model parameters. Only for testing purposes."""
-        model_params = await self.policy_worker.get_model_params.choose()
+        model_params = await self.policy_worker._get_model_params.choose()
         return model_params
 
     @endpoint
@@ -486,7 +486,7 @@ class PolicyWorker(ForgeActor):
         return self.vllm_args
 
     @endpoint
-    async def get_model_params(self) -> Dict[str, torch.Tensor]:
+    async def _get_model_params(self) -> Dict[str, torch.Tensor]:
         model = self.worker.model_runner.model
         state_dict = {}
 

--- a/tests/integration_tests/test_policy_update.py
+++ b/tests/integration_tests/test_policy_update.py
@@ -220,7 +220,7 @@ async def run_policy_integration(
         "Successfully called Policy.update_weights() to load weights from torchstore!"
     )
     # We get the result as a list.
-    results = await policy.get_model_params.call()
+    results = await policy._get_model_params.call()
     assert len(results) == 1
     print("Successfully got model state dict after update")
     return results[0]


### PR DESCRIPTION
Policy engine introduce a Policy service. This broke the existing vllm + torchstore example script.
This diff fixes it. 

1. Only the single worker case is fixed here.
2 Will fix the multi-worker case in followup PR. 

