### PR TITLE
[ez] Fix app/vllm response processing broken by change in policy

### DIFF
--- a/apps/vllm/main.py
+++ b/apps/vllm/main.py
@@ -13,7 +13,6 @@ python -m apps.vllm.main --guided-decoding --num-samples 3
 import argparse
 import asyncio
 from argparse import Namespace
-from typing import List
 
 from forge.actors.policy import Policy, PolicyConfig, SamplingOverrides, WorkerConfig
 from forge.controller.service import ServiceConfig, shutdown_service, spawn_service


### PR DESCRIPTION
`policy.generate` return type was changed from `List[CompletionOutput]` to `RequestOutput` in https://github.com/meta-pytorch/forge/pull/94, but wasn't updated to vllm/main

Simple PR to fix app