### PR TITLE
vLLM main - support for different models

### DIFF
--- a/apps/vllm/main.py
+++ b/apps/vllm/main.py
@@ -46,7 +46,6 @@ def parse_args() -> Namespace:
         "--model",
         type=str,
         default="meta-llama/Llama-3.1-8B-Instruct",
-        # default="deepseek-ai/DeepSeek-R1-0528",
         help="Model to use",
     )
     parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size")

--- a/apps/vllm/main.py
+++ b/apps/vllm/main.py
@@ -12,11 +12,15 @@ python -m apps.vllm.main --guided-decoding --num-samples 3
 
 import argparse
 import asyncio
+import os
 from argparse import Namespace
 
 from forge.actors.policy import Policy, PolicyConfig, SamplingOverrides, WorkerConfig
 from forge.controller.service import ServiceConfig, shutdown_service, spawn_service
 from vllm.outputs import RequestOutput
+
+os.environ["HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT_SECS"] = "600"
+os.environ["HYPERACTOR_CODE_MAX_FRAME_LENGTH"] = "1073741824"
 
 
 async def main():


### PR DESCRIPTION
A few changes:
- In the vLLM main application, introduce knobs for model and tp size which controls the replica size
- In policy, instead of passing vllm_args around, we just create it for both the policy and workers. This was otherwise running into some Monarch unpickling weirdness with UntypedStorage that really was not worth the effort to debug.
- Uses torchstore's singleton APIs instead - because this isn't landed yet in TorchStore we shouldn't land it here