### PR TITLE
fix the path for the tokenizer

### DIFF
--- a/apps/sft_v2/llama3_8b.yaml
+++ b/apps/sft_v2/llama3_8b.yaml
@@ -14,7 +14,7 @@ comm:
 model:
   name: llama3
   flavor: 8B
-  tokenizer_path: /tmp/Llama-3.1-8B-Instruct
+  tokenizer_path: /tmp/Meta-Llama-3.1-8B-Instruct
 
 processes:
   scheduler: local # local | mast (not supported yet)


### PR DESCRIPTION
Fixing the default path for the llama3.1-8B tokenizer as the everything regarding the model will be downloaded to `/tmp/Meta-Llama-3.1-8B-Instruct`.