### PR TITLE
[icebox][ez-ish] Collect compute_logprobs into util

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -26,6 +26,7 @@ from forge.controller.provisioner import shutdown
 from forge.controller.service import ServiceConfig, shutdown_service, spawn_service
 from forge.data.rewards import MathReward, ThinkingReward
 from forge.data.utils import exclude_service
+from forge.util import compute_logprobs
 from forge.util.metric_logging import get_metric_logger
 from monarch.actor import endpoint
 from omegaconf import DictConfig
@@ -34,21 +35,6 @@ from torchstore.state_dict_utils import DELIM
 from torchtitan.config.job_config import Model as TitanJobModelConfig
 from transformers import AutoModelForCausalLM
 from vllm.transformers_utils.tokenizer import get_tokenizer
-
-
-def compute_logprobs(
-    logits: torch.Tensor, input_ids: torch.Tensor, temperature: float = 1.0
-) -> torch.Tensor:
-    context_length = logits.shape[1] - input_ids.shape[1]
-
-    # Truncate request logits and drop last
-    logits = logits[:, context_length - 1 : -1]
-
-    # Compute logprobs
-    logprobs = torch.log_softmax(logits / temperature, dim=-1)
-    logprobs = torch.gather(logprobs, 2, input_ids.unsqueeze(-1)).squeeze(-1)
-
-    return logprobs
 
 
 class SimpleGRPOLoss(nn.Module):

--- a/src/forge/actors/reference_model.py
+++ b/src/forge/actors/reference_model.py
@@ -21,6 +21,7 @@ from torchtitan.experiments.forge.engine import ForgeEngine
 from torchtitan.experiments.forge.job_config import ForgeJobConfig
 
 from forge.controller import ForgeActor
+from forge.util import compute_logprobs
 
 
 logger = logging.getLogger(__name__)
@@ -131,44 +132,3 @@ class ReferenceModel(ForgeActor):
                     return logprobs.squeeze(0)
 
         return pred
-
-
-# Based on torchtune's grpo
-def compute_logprobs(
-    logits: torch.Tensor, input_ids: torch.Tensor, temperature: float = 1.0
-) -> torch.Tensor:
-    """
-    Compute log probs of the completion input_ids given the logits of the whole sequence.
-    Warning: only works if all prompts in the batch have the same length. TODO: support variable length prompts.
-
-    Args:
-        logits (torch.Tensor): (batch_size, seq_len, vocab_size), the logits output from the model.
-        input_ids (torch.Tensor): (batch_size, completion_len), the token ids for the completion.
-
-    Returns:
-        torch.Tensor: (batch_size, completion_len), the log probabilities of the completion tokens.
-
-    Raises:
-        ValueError: If the inferred context length is less than or equal to 0.
-    """
-    context_len = logits.shape[1] - input_ids.shape[1]
-    completion_len = input_ids.shape[1]
-    if context_len <= 0:
-        raise ValueError(
-            "Context length must be greater than 0. Otherwise the probability of the first token is undefined."
-        )
-
-    # (bsz, completion_len, vocab_size)
-    logits = logits[:, context_len - 1 : -1, :]
-    assert logits.shape == (
-        input_ids.shape[0],
-        completion_len,
-        logits.shape[-1],
-    ), f"logits shape incorrect, {logits.shape=}, {input_ids.shape=}, {logits.shape[-1]=}"
-    token_logprobs = torch.log_softmax(logits / temperature, dim=-1)
-    # (bsz, completion_len, 1)
-    logprobs = torch.gather(token_logprobs, 2, input_ids.unsqueeze(-1))
-    # (bsz, completion_len)
-    logprobs = logprobs.squeeze(-1)
-
-    return logprobs

--- a/src/forge/util/__init__.py
+++ b/src/forge/util/__init__.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from .compute_logprobs import compute_logprobs
 from .distributed import get_world_size_and_rank
 from .logging import get_logger, log_once, log_rank_zero
 from .metric_logging import get_metric_logger
@@ -13,4 +14,5 @@ __all__ = [
     "log_once",
     "log_rank_zero",
     "get_metric_logger",
+    "compute_logprobs",
 ]

--- a/src/forge/util/compute_logprobs.py
+++ b/src/forge/util/compute_logprobs.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+
+
+def compute_logprobs(
+    logits: torch.Tensor, input_ids: torch.Tensor, temperature: float = 1.0
+) -> torch.Tensor:
+    """
+    Compute log probs of the completion input_ids given the logits of the whole sequence.
+    Warning: only works if all prompts in the batch have the same length. TODO: support variable length prompts.
+
+    Args:
+        logits (torch.Tensor): (batch_size, seq_len, vocab_size), the logits output from the model.
+        input_ids (torch.Tensor): (batch_size, completion_len), the token ids for the completion.
+
+    Returns:
+        torch.Tensor: (batch_size, completion_len), the log probabilities of the completion tokens.
+
+    Raises:
+        ValueError: If the inferred context length is less than or equal to 0.
+    """
+    context_len = logits.shape[1] - input_ids.shape[1]
+    completion_len = input_ids.shape[1]
+    if context_len <= 0:
+        raise ValueError(
+            "Context length must be greater than 0. Otherwise the probability of the first token is undefined."
+        )
+
+    # (bsz, completion_len, vocab_size)
+    logits = logits[:, context_len - 1 : -1, :]
+    assert logits.shape == (
+        input_ids.shape[0],
+        completion_len,
+        logits.shape[-1],
+    ), f"logits shape incorrect, {logits.shape=}, {input_ids.shape=}, {logits.shape[-1]=}"
+    token_logprobs = torch.log_softmax(logits / temperature, dim=-1)
+    # (bsz, completion_len, 1)
+    logprobs = torch.gather(token_logprobs, 2, input_ids.unsqueeze(-1))
+    # (bsz, completion_len)
+    logprobs = logprobs.squeeze(-1)
+
+    return logprobs

--- a/tests/unit_tests/test_compute_logprobs.py
+++ b/tests/unit_tests/test_compute_logprobs.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Tests for reference_actor.py - compute_logprobs function
+Tests for compute_logprobs function
 """
 
 import unittest
@@ -13,27 +13,14 @@ import unittest
 import pytest
 import torch
 
-
-def _import_error():
-    try:
-        import forge.actors.reference_model  # noqa: F401
-
-        return False
-    except Exception:
-        return True
+from forge.util import compute_logprobs
 
 
 class TestComputeLogprobs(unittest.TestCase):
     """Test the compute_logprobs utility function."""
 
-    @pytest.mark.skipif(
-        _import_error(),
-        reason="Import error, likely due to missing dependencies on CI.",
-    )
     def test_compute_logprobs_basic(self):
         """Test basic logprobs computation."""
-        from forge.actors.reference_model import compute_logprobs
-
         batch_size = 1
         seq_len = 5
         vocab_size = 1000
@@ -51,14 +38,8 @@ class TestComputeLogprobs(unittest.TestCase):
         assert result.shape == (batch_size, response_len)
         assert torch.all(result <= 0)  # Log probabilities should be <= 0
 
-    @pytest.mark.skipif(
-        _import_error(),
-        reason="Import error, likely due to missing dependencies on CI.",
-    )
     def test_compute_logprobs_with_temperature(self):
         """Test logprobs computation with temperature scaling."""
-        from forge.actors.reference_model import compute_logprobs
-
         batch_size = 1
         seq_len = 5
         vocab_size = 1000
@@ -76,14 +57,8 @@ class TestComputeLogprobs(unittest.TestCase):
         default_result = compute_logprobs(logits, input_ids)
         assert not torch.allclose(result, default_result)
 
-    @pytest.mark.skipif(
-        _import_error(),
-        reason="Import error, likely due to missing dependencies on CI.",
-    )
     def test_compute_logprobs_single_token(self):
         """Test logprobs computation with single token response."""
-        from forge.actors.reference_model import compute_logprobs
-
         batch_size = 1
         seq_len = 5
         vocab_size = 1000
@@ -97,14 +72,8 @@ class TestComputeLogprobs(unittest.TestCase):
         assert result.shape == (batch_size, response_len)
         assert result.numel() == 1  # Single element
 
-    @pytest.mark.skipif(
-        _import_error(),
-        reason="Import error, likely due to missing dependencies on CI.",
-    )
     def test_compute_logprobs_empty_response(self):
         """Test logprobs computation with empty response."""
-        from forge.actors.reference_model import compute_logprobs
-
         batch_size = 1
         seq_len = 5
         vocab_size = 1000
@@ -117,14 +86,8 @@ class TestComputeLogprobs(unittest.TestCase):
 
         assert result.shape == (batch_size, response_len)
 
-    @pytest.mark.skipif(
-        _import_error(),
-        reason="Import error, likely due to missing dependencies on CI.",
-    )
     def test_compute_logprobs_empty_prompt(self):
         """Test logprobs computation with empty prompt."""
-        from forge.actors.reference_model import compute_logprobs
-
         batch_size = 1
         vocab_size = 1000
         prompt_len = 0


### PR DESCRIPTION
Currently `compute_logprobs` is repeated in 3 different locations (2 of which are literally identical). This just puts them all in one place under `util/compute_logprobs.py`

Locations
* `apps/grpo/main.py`
* `apps/rl/main.py` --- Identical to grpo's
* `src/forge/actors/reference_model.py`

---

Note that the third definition in `reference_model` is functionally identical to that of the main.py files

Main.py implementations
``` python
def compute_logprobs(
    logits: Tensor, input_ids: torch.Tensor, temperature: float = 1.0
) -> Tensor:
    context_length = logits.shape[1] - input_ids.shape[1]

    # Truncate request logits and drop last
    logits = logits[:, context_length - 1 : -1]

    # Compute logprobs
    logprobs = torch.log_softmax(logits / temperature, dim=-1)
    logprobs = torch.gather(logprobs, 2, input_ids.unsqueeze(-1)).squeeze(-1)

    return logprobs
```

Util implementation (With assert checks redacted)
``` python
def compute_logprobs(
    logits: torch.Tensor, input_ids: torch.Tensor, temperature: float = 1.0
) -> torch.Tensor:
    context_len = logits.shape[1] - input_ids.shape[1]

    # (bsz, completion_len, vocab_size)
    logits = logits[:, context_len - 1 : -1, :].         # Difference here is a no-op all-slice {:}
    
    token_logprobs = torch.log_softmax(logits / temperature, dim=-1)
    # (bsz, completion_len, 1)
    logprobs = torch.gather(token_logprobs, 2, input_ids.unsqueeze(-1))    # Difference is that it got split to 2 lines
    # (bsz, completion_len)
    logprobs = logprobs.squeeze(-1)

    return logprobs
```