### PR TITLE
Trainer + reference model in bf16

### DIFF
--- a/apps/grpo/qwen3_1_7b.yaml
+++ b/apps/grpo/qwen3_1_7b.yaml
@@ -46,7 +46,8 @@ trainer:
     local_batch_size: ${batch_size}
     seq_len: 2048
     max_norm: 1.0
-    steps: 5
+    steps: 1000000
+    dtype: bfloat16
   compile:
     enable: false
   parallelism:
@@ -80,6 +81,8 @@ ref_model:
     name: qwen3
     flavor: 1.7B
     hf_assets_path: hf://${model}
+  training:
+    dtype: bfloat16
   compile:
     enable: false
   parallelism:

--- a/src/forge/actors/reference_model.py
+++ b/src/forge/actors/reference_model.py
@@ -15,7 +15,13 @@ import torch
 from monarch.actor import current_rank, current_size, endpoint
 from torch.distributed.tensor import DTensor
 
-from torchtitan.config.job_config import Checkpoint, Compile, Model, Parallelism
+from torchtitan.config.job_config import (
+    Checkpoint,
+    Compile,
+    Model,
+    Parallelism,
+    Training,
+)
 from torchtitan.experiments.forge.engine import ForgeEngine
 from torchtitan.experiments.forge.job_config import ForgeJobConfig
 
@@ -29,6 +35,9 @@ class ReferenceModel(ForgeActor):
     parallelism: Parallelism = field(default_factory=Parallelism)
     checkpoint: Checkpoint = field(default_factory=Checkpoint)
     compile: Compile = field(default_factory=Compile)
+    training: Training = field(
+        default_factory=Training
+    )  # Only needed in order to correctly set a lower dtype
 
     # Populated in setup
     # TODO: Commented out since engine_config parsing extracts from class members


### PR DESCRIPTION
### What does this PR do?

1. The PR defaults the dtype of the Trainer and ReferenceModel to bf16
2. I also slipped in a change which lets training proceed for as long as needed (toggled by the `steps` param in trainer. DW about it :)

### How do we know this works?

The primary way we know this works is by examining the memory that is taken up when running the models. I confirmed that it is about half by looking at nvtop logs. Luckily we also have another easy way to confirm this works b/c when you try to calculate rms norm with an input in bfloat16 and a weight in fp32, it shows this error:

```
[0] /home/jrcummings/.fbpkg_conda_envs/forge-a7401c7/lib/python3.10/site-packages/torch/nn/functional.py:2920: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /mnt/code/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
[0]   return torch.rms_norm(input, normalized_shape, weight, eps)
```

When this change is merged, the error goes away.

### FAQs

1. **Does this work for single device?** What an astute question: NO. Distributed APIs handle the conversion to a lower dtype, so if you don't use the distributed APIs it will keep things in fp32. This is annoying, for sure, but not blocking. Keep tracking [this issue](https://github.com/pytorch/torchtitan/issues/1525) for more information.
2. **What about training stability?** Fair play. While it is common practice to post-train in bf16, people have raised concerns that performance is worse than fp32. See [here](https://github.com/pytorch/torchtitan/pull/1646#issuecomment-3305159515). Experiments before and after this change don't raise any red flags, but I would consider this part of the ongoing "correctness" work to ensure this doesn't cause any problems. cc @Ritesh1905 
