### PR TITLE
Rename `procs_per_replica`/`hosts_per_replica` to `procs`/`hosts`

### DIFF
--- a/apps/grpo/qwen3_1_7b.yaml
+++ b/apps/grpo/qwen3_1_7b.yaml
@@ -96,30 +96,30 @@ ref_model:
 # All resource allocations
 services:
   dataset:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   policy:
-    procs_per_replica: ${policy.engine_config.tensor_parallel_size}
+    procs: ${policy.engine_config.tensor_parallel_size}
     num_replicas: 1
     with_gpus: true
   trainer:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: true
   replay_buffer:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   ref_model:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: true
   compute_advantages:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   reward_actor:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false

--- a/apps/grpo/qwen3_multinode.yaml
+++ b/apps/grpo/qwen3_multinode.yaml
@@ -47,32 +47,32 @@ ref_model:
 
 services:
   dataset:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   policy:
-    procs_per_replica: 1
-    hosts_per_replica: 1
+    procs: 1
+    hosts: 1
     num_replicas: 1
     with_gpus: true
   trainer:
-    procs_per_replica: 1
-    hosts_per_replica: 1
+    procs: 1
+    hosts: 1
     num_replicas: 1
     with_gpus: true
   replay_buffer:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   compute_advantages:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   ref_model:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: true
   reward_actor:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false

--- a/apps/rl/main.py
+++ b/apps/rl/main.py
@@ -136,11 +136,11 @@ def simple_grpo_loss(
 
 async def run(cfg: DictConfig):
     trainer = await RLTrainer.options(
-        procs_per_replica=1, with_gpus=True, num_replicas=4
+        procs=1, with_gpus=True, num_replicas=4
     ).as_service(**cfg.trainer)
-    replay_buffer = await ReplayBuffer.options(
-        procs_per_replica=1, num_replicas=1
-    ).as_service(**cfg.replay_buffer)
+    replay_buffer = await ReplayBuffer.options(procs=1, num_replicas=1).as_service(
+        **cfg.replay_buffer
+    )
 
     print("Services initialized....")
 

--- a/apps/toy_rl/sumdigits.yaml
+++ b/apps/toy_rl/sumdigits.yaml
@@ -41,22 +41,22 @@ replay_buffer:
 
 services:
   dataset:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   policy:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: true
   trainer:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: true
   replay_buffer:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false
   reward_actor:
-    procs_per_replica: 1
+    procs: 1
     num_replicas: 1
     with_gpus: false

--- a/apps/vllm/deepseek_r1.yaml
+++ b/apps/vllm/deepseek_r1.yaml
@@ -13,8 +13,8 @@ policy:
 
 services:
   policy:
-    procs_per_replica: 8
-    hosts_per_replica: 2
+    procs: 8
+    hosts: 2
     num_replicas: 1
     with_gpus: true
 

--- a/apps/vllm/llama3_8b.yaml
+++ b/apps/vllm/llama3_8b.yaml
@@ -11,7 +11,7 @@ policy:
 
 services:
   policy:
-    procs_per_replica: 2
+    procs: 2
     num_replicas: 1
     with_gpus: true
 

--- a/apps/vllm/qwen2_5_32b.yaml
+++ b/apps/vllm/qwen2_5_32b.yaml
@@ -11,8 +11,8 @@ policy:
 
 services:
   policy:
-    procs_per_replica: 4
-    hosts_per_replica: 1
+    procs: 4
+    hosts: 1
     num_replicas: 1
     with_gpus: true
 

--- a/src/forge/controller/actor.py
+++ b/src/forge/controller/actor.py
@@ -50,7 +50,7 @@ class ForgeActor(Actor):
         *,
         service_config: ServiceConfig | None = None,
         num_replicas: int | None = None,
-        procs_per_replica: int | None = None,
+        procs: int | None = None,
         **service_kwargs,
     ) -> Type[T]:
         """
@@ -61,16 +61,16 @@ class ForgeActor(Actor):
             # Option A: construct ServiceConfig implicitly
             service = await MyForgeActor.options(
                 num_replicas=1,
-                procs_per_replica=2,
+                procs=2,
             ).as_service(...)
             await service.shutdown()
 
             # Option B: provide an explicit ServiceConfig
-            cfg = ServiceConfig(num_replicas=1, procs_per_replica=2, ..)
+            cfg = ServiceConfig(num_replicas=1, procs=2, ..)
             service = await MyForgeActor.options(service_config=cfg).as_service(...)
             await service.shutdown()
 
-            # Option C: skip options, use the default service config with num_replicas=1, procs_per_replica=1
+            # Option C: skip options, use the default service config with num_replicas=1, procs=1
             service = await MyForgeActor.as_service(...)
             await service.shutdown()
         """
@@ -78,13 +78,13 @@ class ForgeActor(Actor):
         if service_config is not None:
             cfg = service_config
         else:
-            if num_replicas is None or procs_per_replica is None:
+            if num_replicas is None or procs is None:
                 raise ValueError(
-                    "Must provide either `service_config` or (num_replicas + procs_per_replica)."
+                    "Must provide either `service_config` or (num_replicas + procs)."
                 )
             cfg = ServiceConfig(
                 num_replicas=num_replicas,
-                procs_per_replica=procs_per_replica,
+                procs=procs,
                 **service_kwargs,
             )
 
@@ -107,7 +107,7 @@ class ForgeActor(Actor):
         # Use _service_config if already set by options(), else default
         cfg = getattr(cls, "_service_config", None)
         if cfg is None:
-            cfg = ServiceConfig(num_replicas=1, procs_per_replica=1)
+            cfg = ServiceConfig(num_replicas=1, procs=1)
             # dynamically create a configured subclass for consistency
             cls = type(f"{cls.__name__}Configured", (cls,), {"_service_config": cfg})
 

--- a/src/forge/types.py
+++ b/src/forge/types.py
@@ -98,27 +98,35 @@ class ProcessConfig:
 
 @dataclass
 class ServiceConfig:
-    """A service config."""
+    """
+    A service config.
+    Args:
+        procs (int): Number of processes to launch for each replica of the service.
+        num_replicas (int): Number of replicas to launch for the service.
+        with_gpus (bool, optional): Whether to allocate GPUs for the service processes.
+        hosts (int | None, optional): Number of hosts to allocate for each replica.
+        health_poll_rate (float, optional): Frequency (in seconds) to poll for health status.
+        replica_max_concurrent_requests (int, optional): Maximum number of concurrent requests per replica.
+        return_first_rank_result (bool, optional): Whether to auto-unwrap ValueMesh to the first rank's result.
+    """
 
-    procs_per_replica: int
+    procs: int
     num_replicas: int
     with_gpus: bool = False
-    hosts_per_replica: int | None = None
+    hosts: int | None = None
     # ServiceConfig-specific fields
     health_poll_rate: float = 0.2
     replica_max_concurrent_requests: int = 10
-    return_first_rank_result: bool = (
-        True  # Whether or not to auto-unwrap ValueMesh to first rank's result
-    )
+    return_first_rank_result: bool = True
 
     def to_process_config(self) -> ProcessConfig:
         """Extract ProcessConfig from this ServiceConfig.
-        Maps procs_per_replica to num_procs for ProcessConfig.
+        Maps procs to num_procs for ProcessConfig.
         """
         return ProcessConfig(
-            num_procs=self.procs_per_replica,
+            num_procs=self.procs,
             with_gpus=self.with_gpus,
-            num_hosts=self.hosts_per_replica,
+            num_hosts=self.hosts,
         )
 
 

--- a/tests/integration_tests/test_policy_update.py
+++ b/tests/integration_tests/test_policy_update.py
@@ -184,9 +184,7 @@ def get_configs(
         "engine_config": engine_config,
         "sampling_config": sampling_config,
     }
-    service_config = ServiceConfig(
-        procs_per_replica=worker_size, num_replicas=1, with_gpus=True
-    )
+    service_config = ServiceConfig(procs=worker_size, num_replicas=1, with_gpus=True)
     return policy_config, service_config
 
 
@@ -256,7 +254,7 @@ class TestWeightSync:
         await ts.initialize()
         # 2. Trainer push
         rl_trainer = await RLTrainer.options(
-            procs_per_replica=worker_size, with_gpus=True, num_replicas=1
+            procs=worker_size, with_gpus=True, num_replicas=1
         ).as_service(**trainer_cfg)
 
         await rl_trainer.push_weights.choose(policy_version=0)
@@ -296,7 +294,7 @@ class TestWeightSync:
         await ts.initialize()
         # 2. Trainer push
         rl_trainer = await RLTrainer.options(
-            procs_per_replica=trainer_worker_size, with_gpus=True, num_replicas=1
+            procs=trainer_worker_size, with_gpus=True, num_replicas=1
         ).as_service(**trainer_cfg_tp)
 
         await rl_trainer.push_weights.call(policy_version=0)


### PR DESCRIPTION
- Renamed `num_procs` to `procs` and `num_hosts` to `hosts` in [`ProcessConfig`](https://github.com/meta-pytorch/forge/blob/0096e728a26da9ff1363b3d327c0b01ba51bcab0/src/forge/types.py#L91)
- Renamed `procs_per_replica` to `procs` and `hosts_per_replica` to `hosts`in [`ServiceConfig`](https://github.com/meta-pytorch/forge/blob/0096e728a26da9ff1363b3d327c0b01ba51bcab0/src/forge/types.py#L100).
- Added docstrings to clarify the meaning and usage of `procs` and `hosts` fields in [`ServiceConfig`](https://github.com/meta-pytorch/forge/blob/0096e728a26da9ff1363b3d327c0b01ba51bcab0/src/forge/types.py#L100).
- Renamed all instances for consistency across codebase and configs.


**Test**
```
pytest tests/unit_tests/test_service.py
python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml
```