### PR TITLE
Garbage collect on every train / ref model step

### DIFF
--- a/apps/grpo/qwen3_1_7b.yaml
+++ b/apps/grpo/qwen3_1_7b.yaml
@@ -48,6 +48,7 @@ trainer:
     max_norm: 1.0
     steps: 1000000
     dtype: bfloat16
+    gc_freq: 1
   compile:
     enable: false
   parallelism:
@@ -83,6 +84,7 @@ ref_model:
     hf_assets_path: hf://${model}
   training:
     dtype: bfloat16
+    gc_freq: 1
   compile:
     enable: false
   parallelism:

--- a/src/forge/actors/reference_model.py
+++ b/src/forge/actors/reference_model.py
@@ -37,7 +37,7 @@ class ReferenceModel(ForgeActor):
     compile: Compile = field(default_factory=Compile)
     training: Training = field(
         default_factory=Training
-    )  # Only needed in order to correctly set a lower dtype
+    )  # Needed in order to set attrs like dtype, garbage collection freq, etc.
 
     # Populated in setup
     # TODO: Commented out since engine_config parsing extracts from class members
@@ -61,6 +61,7 @@ class ReferenceModel(ForgeActor):
         """
         self.rank = current_rank().rank
         self.size = math.prod(current_size().values())
+        self.step = 0
 
         env = {
             "RANK": str(self.rank),
@@ -83,7 +84,7 @@ class ReferenceModel(ForgeActor):
 
     @endpoint
     async def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
-        self.engine.gc_handler.collect(reason="Periodic GC collection")
+        self.engine.gc_handler.run(self.step)
         model_parts = self.engine.model_parts
         parallel_dims = self.engine.parallel_dims
         input_ids = input_ids.to("cuda")
@@ -107,6 +108,7 @@ class ReferenceModel(ForgeActor):
                 with self.engine.maybe_enable_amp:
                     with torch.inference_mode():
                         logits = model_parts[0](input_ids)
+        self.step += 1
         if isinstance(logits, DTensor):
             logits = logits.full_tensor()
         return logits

--- a/src/forge/actors/trainer.py
+++ b/src/forge/actors/trainer.py
@@ -15,9 +15,6 @@ import torch
 import torch.distributed.checkpoint as dcp
 import torchstore as ts
 
-from forge.controller import ForgeActor
-from forge.data.utils import batch_to_device
-
 from monarch.actor import current_rank, current_size, endpoint
 from torch import Tensor
 from torch.distributed.checkpoint._nested_dict import flatten_state_dict
@@ -36,6 +33,9 @@ from torchtitan.config.job_config import (
 )
 from torchtitan.experiments.forge.engine import ForgeEngine
 from torchtitan.experiments.forge.job_config import ForgeJobConfig
+
+from forge.controller import ForgeActor
+from forge.data.utils import batch_to_device
 
 
 @dataclass
@@ -73,7 +73,7 @@ class RLTrainer(ForgeActor):
                     f"{f.name} should be a {f.type} type or a dict like object"
                 )
 
-        self.current_step = 1  # fragile contract.
+        self.step = 1  # fragile contract.
         self.num_training_steps = self.training.steps
         self.gradient_accumulation_steps = 1
         self.rank = current_rank().rank
@@ -100,7 +100,7 @@ class RLTrainer(ForgeActor):
         for key in {"loss", "state_dict_key", "use_dcp"}:
             engine_config.pop(key)  # Not part of job config
         self.engine = ForgeEngine(ForgeJobConfig(**engine_config))
-        self.engine.checkpointer.load(step=self.current_step)
+        self.engine.checkpointer.load(step=self.step)
         self.engine.optimizers.zero_grad()
 
     def forward_backward(
@@ -173,7 +173,7 @@ class RLTrainer(ForgeActor):
     def train_step(
         self, inputs: list[dict[str, Tensor]], targets: list[dict[str, Tensor]]
     ) -> float:
-        self.engine.gc_handler.run(self.current_step)
+        self.engine.gc_handler.run(self.step)
         local_inputs = inputs[self.engine.dp_rank]
         local_targets = targets[self.engine.dp_rank]
         batch_to_device(local_inputs, self.engine.device)
@@ -193,10 +193,10 @@ class RLTrainer(ForgeActor):
         self.engine.optimizers.zero_grad()
         self.engine.lr_schedulers.step()
 
-        self.current_step += 1
+        self.step += 1
         self.engine.checkpointer.save(
-            curr_step=self.current_step,
-            last_step=self.current_step == self.num_training_steps,
+            curr_step=self.step,
+            last_step=self.step == self.num_training_steps,
         )
 
         return loss.item()


### PR DESCRIPTION
### What is this PR?

As reported in #201, there appeared to be a memory leak in the components using TorchTitan - RLTrainer and ReferenceModel. This PR manually calls the [TorchTitan garbage collection util](https://github.com/pytorch/torchtitan/blob/c9cb3046867ca3cacd6771a60acf65ede424715e/torchtitan/tools/utils.py#L37) on every step, which eliminates the memory leak.

### How was this PR tested?

With ``gc_freq: 100000`` (never running essentially)
<img width="531" height="305" alt="Screenshot 2025-09-22 at 1 43 19 PM" src="https://github.com/user-attachments/assets/7d9de4c1-ffe4-4d01-a636-cc9c8582122f" />

Notice the yellow line (reference model) and the ref line (trainer model) consistently going up.

With ``gc_freq: 1`` (run every step)
<img width="450" height="285" alt="Screenshot 2025-09-22 at 3 19 55 PM" src="https://github.com/user-attachments/assets/6a1726d1-de52-4b32-aded-c9cbea937d8c" />

Notice the yellow line (reference model) and red line (trainer model) stays relatively flat.

### FAQs

1. **Why is this happening?** ~~The theory is that Monarch doesn't know that it is able to free memory after returning from an Endpoint. So every time the Endpoint (either ``forward`` or ``train_step``) is called, new memory is allocated. This theory definitely requires further investigation, but the fix lends credibility.~~ Actually Titan disables garbage collection manually to improve performance. We have to re-enable it with this PR.
2. **How long does garbage collection take? Could this be a bottleneck?** Garbage collection times are logged. In my experiments the longest it takes is 1 ms. 