### PR TITLE
Fix Policy.launch to be compatible with new ForgeActor.launch API

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -150,7 +150,6 @@ class Policy(PolicyInterface):
     async def launch(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls: type["Policy"],
         *,
-        process_config: ProcessConfig,
         engine_config: EngineConfig | Mapping = EngineConfig(),
         sampling_config: SamplingConfig | Mapping = SamplingConfig(),
         available_devices: str | None = None,
@@ -158,6 +157,11 @@ class Policy(PolicyInterface):
     ) -> "Policy":
         # Note - get_proc_mesh will set MASTER_ADDR, MASTER_PORT and CUDA_VISIBLE_DEVICES
         # automatically.
+        process_config: ProcessConfig = ProcessConfig(
+            procs=cls.procs,
+            hosts=cls.hosts,
+            with_gpus=cls.with_gpus,
+        )
         worker_procs = await get_proc_mesh(process_config=process_config)
 
         # TODO - issues/144 we will want to ensure colocation with workers


### PR DESCRIPTION
This PR updates `Policy.launch` to match the new `ForgeActor.launch` API, removing the `process_config` argument and construct it inside of `launch`. 


Specifically fixed the error
```
TypeError: Policy.launch() missing 1 required keyword-only argument: 'process_config'
```


**Test**
```
python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml
pytest -s --log-cli-level=INFO  tests/unit_tests/test_service.py
```

cc @casteryh @vidhyav @felipemello1 