### PR TITLE
Raise NotImplementedError for Monarch-style Methods on ServiceEndpoint

### DIFF
--- a/src/forge/controller/service/interface.py
+++ b/src/forge/controller/service/interface.py
@@ -101,6 +101,36 @@ class ServiceEndpoint(Generic[P, R]):
         result = await self.service.call_all(self.endpoint_name, *args, **kwargs)
         return result
 
+    async def choose(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        raise NotImplementedError(
+            "You tried to use choose() on a service, not an actor. "
+            "Services only support route() and fanout()."
+        )
+
+    async def call(self, *args: P.args, **kwargs: P.kwargs) -> List[R]:
+        raise NotImplementedError(
+            "You tried to use call() on a service, not an actor. "
+            "Services only support route() and fanout()."
+        )
+
+    async def call_one(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        raise NotImplementedError(
+            "You tried to use a call_one() on a service, not an actor. "
+            "Services only support route() and fanout()."
+        )
+
+    async def broadcast(self, *args: P.args, **kwargs: P.kwargs) -> List[R]:
+        raise NotImplementedError(
+            "You tried to use broadcast() on a service, not an actor. "
+            "Services only support route() and fanout()."
+        )
+
+    async def generate(self, *args: P.args, **kwargs: P.kwargs):
+        raise NotImplementedError(
+            "You tried to use generate() on a service, not an actor. "
+            "Services only support route() and fanout()."
+        )
+
 
 class ServiceEndpointV2(Generic[P, R]):
     """An endpoint object specific to services.

--- a/tests/unit_tests/test_service.py
+++ b/tests/unit_tests/test_service.py
@@ -214,6 +214,42 @@ async def test_multiple_services_isolated_configs():
         await service2.shutdown()
 
 
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_service_endpoint_monarch_method_error():
+    """Test that calling Monarch-style methods on a service endpoint raises NotImplementedError."""
+    service = await Counter.options(procs=1, num_replicas=1).as_service(0)
+    try:
+        # Try to call a Monarch-style method and check for the error
+        with pytest.raises(
+            NotImplementedError,
+            match="You tried to use a call_one",
+        ):
+            await service.value.call_one()
+        with pytest.raises(
+            NotImplementedError,
+            match="You tried to use broadcast",
+        ):
+            await service.value.broadcast()
+        with pytest.raises(
+            NotImplementedError,
+            match="You tried to use generate",
+        ):
+            await service.value.generate()
+        with pytest.raises(
+            NotImplementedError,
+            match="You tried to use choose",
+        ):
+            await service.value.choose()
+        with pytest.raises(
+            NotImplementedError,
+            match="You tried to use call",
+        ):
+            await service.value.call()
+    finally:
+        await service.shutdown()
+
+
 # Core Functionality Tests
 
 


### PR DESCRIPTION
A follow up on https://github.com/meta-pytorch/forge/pull/222
This pull request introduces explicit error handling for Monarch-style methods (`call_one`, `broadcast`, `generate`, `choose`, `call`) on the `ServiceEndpoint` class. Attempting to invoke these methods on a service endpoint will now raise a `NotImplementedError` with a clear message indicating that these operations are only supported for actors, not services. The error message guides users to use the supported `route()` and `fanout()` methods for service endpoints.

**Testing**

- Added `test_service_endpoint_monarch_method_error` to ensure that each unsupported method raises the correct exception and message.
- All existing and new tests pass.
