### PR TITLE
Add the ability to customize threads in GRPO App

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -366,18 +366,15 @@ async def main(cfg: DictConfig):
     rollout_tasks = [
         asyncio.create_task(continuous_rollouts()) for _ in range(num_rollout_threads)
     ]
-    training_tasks = [
-        asyncio.create_task(continuous_training()) for _ in range(num_training_threads)
-    ]
+    training_task = asyncio.create_task(continuous_training())
 
     try:
-        await asyncio.gather(*rollout_tasks, *training_tasks)
+        await asyncio.gather(*rollout_tasks, training_task)
     except KeyboardInterrupt:
         print("Training interrupted by user")
         for rollout_task in rollout_tasks:
             rollout_task.cancel()
-        for training_task in training_tasks:
-            training_task.cancel()
+        training_task.cancel()
     finally:
         print("Shutting down...")
         await asyncio.gather(

--- a/apps/grpo/qwen3_1_7b.yaml
+++ b/apps/grpo/qwen3_1_7b.yaml
@@ -11,7 +11,6 @@ off_by_n: 1 # Off by one by default
 
 # Main loop configuration
 rollout_threads: 1   # Recommended to set equal to policy.num_replicas
-training_threads: 1  # Recommended to set equal to trainer.num_replicas (usually 1)
 
 # Dataset configuration
 dataset:


### PR DESCRIPTION
Adds the ability to adjusts threads used for rollout and training via the yaml (`rollout_threads`, `training_threads`) defaulting to 1 when not specified.

Also increases the number of policy replicas to 6 for 8 GPU utilization (6 Policy, 1 Trainer, 1 Reference)

---

Initial testing on Qwen3 1.7B (gs=8, bs=16)

_(We'll have a better tools to analyze configs after https://github.com/meta-pytorch/forge/pull/239)_

| threads | time/train loop (min) | % of base case | Comment|
|-------|------|---|---|
| 1  | 0.7  | 100% | Base Case|
| 2 | 0.45 | 64% | Thread x GS == BS |
| 6 | 0.36 | **51%** | Threads === Replica|
| 8 | 0.47 | 67% | Threads > Replica|

### wandb: torchforge/grpo-training/runs/buwmxe2n
- 1 Rollout Thread, ~7 minutes
- ~20 rollouts => **10 training steps** completed
- Notice that the rollout needs to loop twice per training run
<img width="607" height="305" alt="image" src="https://github.com/user-attachments/assets/7ccab610-20aa-45d2-8675-9af7fcea977a" />

### wandb: torchforge/grpo-training/runs/3dwmpt0s
- 2 Rollout Threads, ~ 9 minutes
- ~20 rollouts (per thread) => **20 training steps** completed
- Notice that each version of rollout steps (completed by all threads) correponds to a single training step completion
<img width="607" height="305" alt="image" src="https://github.com/user-attachments/assets/582fe16a-613c-490e-bc68-0f449d5d0eb4" />

### wandb: torchforge/grpo-training/runs/zi7mogyb
- 6 Rollout Thread, ~ 10 minutes
- ~20 rollouts (per thread) => **28 training steps** completed
- Notice the the replaybuffer over populates (bs=16) meaning over generation by rollouts and resulting in discarded samples
- Note that the number of threads matches the number of replicas (replica=6) resulting in at most 6 concurrent vllm runs
<img width="607" height="305" alt="image" src="https://github.com/user-attachments/assets/0f1e848c-a766-4635-9eec-ffdf8cf1c184" />


### wandb: torchforge/grpo-training/runs/fqcdp31y
- 8 Rollout Thread, ~ 14 minutes
- ~20 rollouts (per thread) => **30 training steps** completed
- Notice the the replaybuffer over populates (bs=16) meaning over generation by rollouts and resulting in discarded samples
- Note that the number of threads is greater than the number of replicas (replica=6) resulting in at most 6 concurrent vllm runs
<img width="544" height="314" alt="image" src="https://github.com/user-attachments/assets/463ff999-e843-4eff-934e-1c58c2900c02" />

