### PR TITLE
hotfix - disable time cuda

### DIFF
--- a/src/forge/observability/perf_tracker.py
+++ b/src/forge/observability/perf_tracker.py
@@ -106,7 +106,7 @@ class Tracer:
 
         self.prefix = prefix
         self.track_memory = track_memory
-        self.time_with_gpu = timer == "gpu"
+        self.time_with_gpu = False  # timer == "gpu"
         self._disable = os.getenv(DISABLE_PERF_METRICS, "false") == "true"
         self._active = False
 


### PR DESCRIPTION
TLDR: 
commit right before metric logging -> No OOM
[metric logging](https://github.com/meta-pytorch/forge/pull/239) --> OOM
Disabling cuda stream for time tracking -> No OOM

Hotfix disables time_with_cuda everywhere in forge until further testing. For now it will track time using only cpu, which is not as precise as cuda.

-----

Currently when running `python -m apps.grpo.main --config apps/grpo/qwen3_8b.yaml` we get OOM on the second train step during [loss computation](https://github.com/meta-pytorch/forge/blob/67cf003a3408d49c82caa53d853b8835cbaee8c4/src/forge/actors/trainer.py#L262).

(1) The [metric logging PR](https://github.com/meta-pytorch/forge/pull/239) introduced this bug. One of the functionalities is to set 'timer="gpu"', which uses cuda streams to capture cuda time without blocking.
(2) Forcing it to always use `timer="cpu"` solved the issue.
(3) Upon investigation, I was not able to detect or produce any sort of memory leakage. However, I realized that we have a possible issue with memory fragmentation:
 
For an 8B model on bf16, we expect:
model = 16GBGB 
model + gradients = 32GB 
model + gradients + optimizer state = 64GB 

We should see 32 extra GB at the init of the 2nd forward because now we have optimizer states.

Indeed we see exactly that
```
| Iter/Phase    | Alloc (GB) | Reserved (GB) | Peak (GB) | Frag Signal? |
|---------------|------------|---------------|-----------|--------------|
| 1st: Pre-fwd | 16.4       | 16.4          | 16.4      | model = 16GBGB |
| 1st: Post-fwd | 32.8      | 82.6          | 63.0      | model + gradients = 32GB |
| 2nd: Pre-fwd | 49.2       | 82.6          | 49.2      | model + optimizer state = 48GB |
| 2nd: Post-fwd | 65.6      | 76.8-87.5     | 95.8      | model + gradients + optimizer state = 64GB  |
``````

However, reserved memory is much higher than allocated. We also see a peak~= 95GB, close to max gpu memory of 100GB.

(4) A common solution for memory fragmentation is to use [`expandable_segments`](https://github.com/meta-pytorch/forge/blob/67cf003a3408d49c82caa53d853b8835cbaee8c4/src/forge/actors/trainer.py#L154), which we do, but we set it after importing torch. AFAIK, it doesnt work to in this order and, instead, we have to use `torch.cuda.memory._set_allocator_settings("expandable_segments:True")`

(5) The cuda stream to capture time apparently allocates a bit of memory, but given the GPU limit + fragmentation, it OOMs. This did not happen for qwen 1.7B, for example after >20 steps of training.

-----

Next steps:
- Check if expandable segments solves it
- See if we can reduce impact from cuda stream
- Maybe we are really at the complete peak gpu utilization, and it cannot even tolerate an extra cuda stream.