### PR TITLE
OOM Fix

### DIFF
--- a/apps/grpo/qwen3_8b.yaml
+++ b/apps/grpo/qwen3_8b.yaml
@@ -4,8 +4,8 @@
 # Global configuration
 group_size: 8
 batch_size: 16
-max_req_tokens: 512
-max_res_tokens: 512
+max_req_tokens: 468
+max_res_tokens: 468
 model: "Qwen/Qwen3-8B"
 off_by_n: 1 # Off by one by default
 

--- a/src/forge/observability/perf_tracker.py
+++ b/src/forge/observability/perf_tracker.py
@@ -106,7 +106,7 @@ class Tracer:
 
         self.prefix = prefix
         self.track_memory = track_memory
-        self.time_with_gpu = False  # timer == "gpu"
+        self.time_with_gpu = timer == "gpu"
         self._disable = os.getenv(DISABLE_PERF_METRICS, "false") == "true"
         self._active = False
 
@@ -297,7 +297,7 @@ class _TimerCUDA(_TimerProtocol):
         index = len(self._futures)
         self._futures.append((name, future, index))
 
-        if len(self._futures) >= 20:  # clean up every 20 to avoid memory leak
+        if len(self._futures) >= 5:  # clean up every 5
             self._collect_completed_futures()
 
         self._chain_start = end_event


### PR DESCRIPTION
TLDR: GPU memory utilization was at the peak and any extra allocation/variance caused OOM. Reducing seq_len solves it.

----------

There were reports of Qwen 8B OOMing at later steps in training or at the very second step when using coreweave.

When [metric logging](https://github.com/meta-pytorch/forge/pull/239) was introduced, training would always OOM at the second step during loss computation.

Upon investigation, the hypothesis was that the GPU was working at its very memory limit, and any last straw would make it OOM. To confirm this, I checked out to the last commit before metric logging and added to train step a simple sum:
<img width="678" height="308" alt="552288858_1375177957500210_1077147565638334945_n" src="https://github.com/user-attachments/assets/e08df2f6-4a06-4548-bb1b-0c4a00ca5329" />

This was enough to make it OOM at the second step, confirming the hypothesis. The metric logging caused it because creating a cuda stream to track time also adds negligible memory.

Solution: reduce seq_len 512 -> 468

To confirm it, i [ran >20 steps](https://wandb.ai/cabernet-team/grpo-training/runs/m0z5axv5?nw=nwuserfelipemello) at this setting and metric logging on, without any OOMs.

<img width="1863" height="613" alt="image" src="https://github.com/user-attachments/assets/56e196f4-d624-4719-8873-5f4106f10c12" />


