### PR TITLE
[Logging] Measure policy weight update

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -654,7 +654,8 @@ class PolicyWorker(ForgeActor):
         logger.debug(f"{matching_keys=}")
         dcp_whole_state_dict_key = get_dcp_whole_state_dict_key(version)
         loaded_weights = set()
-        start = time.perf_counter()
+        t = Tracer("policy_worker_perf/update", timer="gpu")
+        t.start()
         # Entire state dict is stored in a single DCP handle
         if dcp_whole_state_dict_key in matching_keys:
             logger.info(
@@ -677,9 +678,7 @@ class PolicyWorker(ForgeActor):
                 loaded = model.load_weights([(name, param)])
                 del param
                 loaded_weights.update(loaded)
-        logger.info(
-            f"[PolicyWorker::update] Updated {len(loaded_weights)} parameters, took {time.perf_counter() - start} seconds"
-        )
+        t.stop()
         logger.debug(f"[PolicyWorker::update] Loaded weights: {loaded_weights}")
 
     @endpoint


### PR DESCRIPTION
Not sure what issue @felipemello1 had earlier but I was able to see:

```
WandbBackend: Logged 92 metrics at step 2
=== [global_logger_5Dxs_r0] - METRICS STEP 2 ===
  buffer/add/count_episodes_added: 16.0
  ...
  policy_worker_perf/update/total_duration_avg_s: 6.04653369140625
  policy_worker_perf/update/total_duration_max_s: 6.04653369140625
  reference_perf/forward/avg_sequence_length: 1024.0
  reference_perf/forward/count_forward_passes: 2.0
==============================
```