### PR TITLE
Re-enable weight cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,5 @@ wandb/
 assets/wheels/vllm*.whl
 
 # DCP artifacts
-model_state_dict/
 forge_dcp_tmp/
 demo_top_down.md

--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -455,9 +455,9 @@ async def main(cfg: DictConfig):
                 await policy.update_weights.fanout(training_step)
                 t.step("update_weights")
 
-                # if training_step >= 2:
-                #     await drop_weights(training_step - 1)
-                #     t.step("drop_weights")
+                if training_step >= 2:
+                    await drop_weights(training_step - 1)
+                    t.step("drop_weights")
 
                 t.stop()
                 restart_tracer = True


### PR DESCRIPTION
Using a fresh environment with `./scripts/install.sh`, this seems to work again (and it's deleting the weights)