### PR TITLE
Add basic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
   attributes:
     label: Versions
     description: |
-      Please share the relevant package versions/commit hash of [pytorch](https://github.com/pytorch/pytorch), [torchtitan](https://github.com/pytorch/torchtitan), [monarch](https://github.com/meta-pytorch/monarch/commits/main), and [vllm](https://github.com/vllm-project/vllm) 
+      Please share the relevant package versions/commit hash of [pytorch](https://github.com/pytorch/pytorch), [torchtitan](https://github.com/pytorch/torchtitan), [monarch](https://github.com/meta-pytorch/monarch), and [vllm](https://github.com/vllm-project/vllm) 
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,40 @@
+name: 🐛 Bug Report
+description: Create a report to help us reproduce and fix the bug
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/meta-pytorch/forge/issues?q=is%3Aissue+sort%3Acreated-desc+).
+- type: textarea
+  attributes:
+    label: 🐛 Describe the bug
+    description: |
+      Please provide a clear and concise description of what the bug is.
+
+      If relevant, add a minimal example so that we can reproduce the error by running the code.
+
+      If the code is too long (hopefully, it isn't), feel free to put it in a public gist and link it in the issue: https://gist.github.com.
+
+      Please also paste or describe the results you observe along with the expected results. If you observe an error, please paste the error message including the **full** traceback of the exception. It may be relevant to wrap error messages in ```` ```triple quotes blocks``` ````.
+    placeholder: |
+      A clear and concise description of what the bug is.
+
+      ```python
+      # Sample code to reproduce the problem
+      ```
+
+      ```
+      The error message you got, with the full traceback.
+      ```
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Versions
+    description: |
+      Please share the relevant package versions/commit hash of [pytorch](https://github.com/pytorch/pytorch), [torchtitan](https://github.com/pytorch/torchtitan), [monarch](https://github.com/meta-pytorch/monarch/commits/main), and [vllm](https://github.com/vllm-project/vllm) 
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: True

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,20 @@
+name: 📚 Documentation
+description: Report an issue or make a request related to documentation 
+
+body:
+- type: textarea
+  attributes:
+    label: 📚 The doc issue
+    description: >
+      A clear and concise description of what content is missing or an issue. Please include the URL to the page or pages with the problem if it exists.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggest a potential alternative/fix
+    description: >
+      Tell us how we could improve the documentation.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -4,7 +4,7 @@ description: Report an issue or make a request related to documentation
 body:
 - type: textarea
   attributes:
-    label: 📚 The doc issue
+    label: 📚 The doc issue or request
     description: >
       A clear and concise description of what content is missing or an issue. Please include the URL to the page or pages with the problem if it exists.
   validations:


### PR DESCRIPTION
Based on the template used by torchchat and executorch

**Example of what this looks like in ET**
<img width="804" height="314" alt="image" src="https://github.com/user-attachments/assets/3514907f-0875-4ebc-8e0b-df6d5e35c4a4" />
