### PR TITLE
Rebranding Policy Implementation as a Generator Implementation

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -21,7 +21,7 @@ from forge.actors._torchstore_utils import (
     get_dcp_whole_state_dict_key,
     get_param_prefix,
 )
-from forge.actors.policy import Policy
+from forge.actors.generator import Generator
 from forge.actors.reference_model import ReferenceModel
 from forge.actors.replay_buffer import ReplayBuffer
 from forge.actors.trainer import RLTrainer
@@ -329,7 +329,7 @@ async def main(cfg: DictConfig):
         reward_actor,
     ) = await asyncio.gather(
         DatasetActor.options(**cfg.actors.dataset).as_actor(**cfg.dataset),
-        Policy.options(**cfg.services.policy).as_service(**cfg.policy),
+        Generator.options(**cfg.services.policy).as_service(**cfg.policy),
         RLTrainer.options(**cfg.actors.trainer).as_actor(
             **cfg.trainer, loss=simple_grpo_loss
         ),

--- a/apps/toy_rl/sumdigits.py
+++ b/apps/toy_rl/sumdigits.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 import torchstore as ts
 from forge.actors._torchstore_utils import get_param_key
-from forge.actors.policy import Policy
+from forge.actors.generator import Generator
 from forge.actors.replay_buffer import ReplayBuffer
 from forge.actors.trainer import _qwen3_hf_to_vllm
 from forge.cli.config import parse
@@ -482,7 +482,7 @@ async def main(cfg: DictConfig):
         ref_model,
     ) = await asyncio.gather(
         DatasetActor.options(**cfg.actors.dataset).as_actor(**cfg.dataset),
-        Policy.options(**cfg.services.policy).as_service(**cfg.policy),
+        Generator.options(**cfg.services.policy).as_service(**cfg.policy),
         Trainer.options(**cfg.actors.trainer).as_actor(**cfg.trainer),
         ReplayBuffer.options(**cfg.actors.replay_buffer).as_actor(**cfg.replay_buffer),
         RewardActor.options(**cfg.services.reward_actor).as_service(),

--- a/apps/vllm/main.py
+++ b/apps/vllm/main.py
@@ -13,7 +13,7 @@ import asyncio
 
 import os
 
-from forge.actors.policy import Policy
+from forge.actors.generator import Generator
 from forge.cli.config import parse
 from forge.controller.provisioner import shutdown
 
@@ -35,7 +35,7 @@ async def run(cfg: DictConfig):
         prompt = "What is 3+5?" if gd else "Tell me a joke"
 
     print("Spawning service...")
-    policy = await Policy.options(**cfg.services.policy).as_service(**cfg.policy)
+    policy = await Generator.options(**cfg.services.policy).as_service(**cfg.policy)
 
     import time
 

--- a/src/forge/actors/__init__.py
+++ b/src/forge/actors/__init__.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__all__ = ["Policy", "PolicyRouter", "RLTrainer", "ReplayBuffer", "TitanRefModel"]
+__all__ = ["Generator", "PolicyRouter", "RLTrainer", "ReplayBuffer", "TitanRefModel"]
 
 
 def __getattr__(name):
-    if name == "Policy":
-        from .policy import Policy
+    if name == "Generator":
+        from .policy import Generator
 
-        return Policy
+        return Generator
     elif name == "PolicyRouter":
         from .policy import PolicyRouter
 

--- a/src/forge/observability/metric_actors.py
+++ b/src/forge/observability/metric_actors.py
@@ -59,7 +59,7 @@ async def get_or_create_metric_logger(
         })
 
         # Initialize services...
-        policy = await Policy.as_service(...)
+        policy = await Generator.as_service(...)
 
         # Training loop
         for step in range(max_steps):

--- a/tests/integration_tests/test_policy_update.py
+++ b/tests/integration_tests/test_policy_update.py
@@ -12,7 +12,7 @@ import pytest
 
 import torch
 import torchstore as ts
-from forge.actors.policy import Policy
+from forge.actors.generator import Generator
 
 from forge.actors.trainer import RLTrainer
 from forge.cli.config import resolve_hf_hub_paths
@@ -203,7 +203,7 @@ class TestWeightSync:
             trainer_cfg["dcp_path"] = tmpdir
             policy, rl_trainer = await asyncio.gather(
                 *[
-                    Policy.options(**services_policy_cfg).as_service(**cfg.policy),
+                    Generator.options(**services_policy_cfg).as_service(**cfg.policy),
                     MockRLTrainer.options(**cfg.actors.trainer).as_actor(**trainer_cfg),
                 ]
             )
@@ -224,7 +224,7 @@ class TestWeightSync:
                 for _, e in errs.items():
                     assert not e, f"Validation failed with exception: {e}"
 
-            await policy.update_weights.fanout(policy_version=v1)
+            await policy.update_weights.fanout(version=v1)
             all_errs = await policy._test_validate_model_params.fanout(
                 validate_fn_all_zeros
             )
@@ -233,7 +233,7 @@ class TestWeightSync:
                     assert not e, f"Validation failed with exception: {e}"
 
             # Reloading v0, getting back original weights
-            await policy.update_weights.fanout(policy_version=v0)
+            await policy.update_weights.fanout(version=v0)
             all_errs = await policy._test_validate_model_params.fanout(validate_fn)
             for errs in all_errs:
                 for _, e in errs.items():

--- a/tests/unit_tests/test_generator_config.py
+++ b/tests/unit_tests/test_generator_config.py
@@ -14,50 +14,52 @@ import yaml
 def _import_error():
     """Check if there are import errors that would cause CI failures."""
     try:
-        import forge.actors.policy  # noqa: F401
+        import forge.actors.generator  # noqa: F401
 
         return False
     except ImportError:
         return True
 
 
-class TestPolicyConfig(unittest.TestCase):
-    """Test suite for Policy configuration handling after PolicyConfig removal."""
+class TestGeneratorConfig(unittest.TestCase):
+    """Test suite for Generator configuration handling after PolicyConfig removal."""
 
     @pytest.mark.skipif(
         _import_error(),
         reason="Import error, likely due to missing dependencies on CI.",
     )
-    def test_policy_default_initialization(self):
-        """Policy initializes with default values."""
-        from forge.actors.policy import EngineConfig, Policy, SamplingConfig
+    def test_generator_default_initialization(self):
+        """Generator initializes with default values."""
+        from forge.actors.generator import EngineConfig, Generator, SamplingConfig
 
-        policy = Policy()
+        generator = Generator()
 
         # Default factories
-        self.assertIsInstance(policy.engine_config, EngineConfig)
-        self.assertIsInstance(policy.sampling_config, SamplingConfig)
-        self.assertIsNone(policy.available_devices)
+        self.assertIsInstance(generator.engine_config, EngineConfig)
+        self.assertIsInstance(generator.sampling_config, SamplingConfig)
+        self.assertIsNone(generator.available_devices)
 
         # Worker defaults
-        self.assertEqual(policy.engine_config.model, "meta-llama/Llama-3.1-8B-Instruct")
-        self.assertEqual(policy.engine_config.tensor_parallel_size, 1)
-        self.assertEqual(policy.engine_config.pipeline_parallel_size, 1)
-        self.assertFalse(policy.engine_config.enforce_eager)
-        self.assertTrue(policy.engine_config._is_v1_supported_oracle())
+        self.assertEqual(
+            generator.engine_config.model, "meta-llama/Llama-3.1-8B-Instruct"
+        )
+        self.assertEqual(generator.engine_config.tensor_parallel_size, 1)
+        self.assertEqual(generator.engine_config.pipeline_parallel_size, 1)
+        self.assertFalse(generator.engine_config.enforce_eager)
+        self.assertTrue(generator.engine_config._is_v1_supported_oracle())
 
         # Sampling defaults
-        self.assertEqual(policy.sampling_config.n, 1)
-        self.assertFalse(policy.sampling_config.guided_decoding)
-        self.assertEqual(policy.sampling_config.max_tokens, 512)
+        self.assertEqual(generator.sampling_config.n, 1)
+        self.assertFalse(generator.sampling_config.guided_decoding)
+        self.assertEqual(generator.sampling_config.max_tokens, 512)
 
     @pytest.mark.skipif(
         _import_error(),
         reason="Import error, likely due to missing dependencies on CI.",
     )
-    def test_policy_with_dict_configs(self):
-        """Policy accepts dicts for engine_config and sampling_config, including nested dicts."""
-        from forge.actors.policy import EngineConfig, Policy, SamplingConfig
+    def test_generator_with_dict_configs(self):
+        """Generator accepts dicts for engine_config and sampling_config, including nested dicts."""
+        from forge.actors.generator import EngineConfig, Generator, SamplingConfig
 
         # Test with nested dict structure
         engine_dict = {
@@ -78,26 +80,26 @@ class TestPolicyConfig(unittest.TestCase):
             "max_tokens": 2468,
         }
 
-        policy = Policy(
+        generator = Generator(
             engine_config=engine_dict,
             sampling_config=sampling_dict,
             available_devices="test-gpu-device-abcd",
         )
 
-        self.assertIsInstance(policy.engine_config, EngineConfig)
-        self.assertIsInstance(policy.sampling_config, SamplingConfig)
+        self.assertIsInstance(generator.engine_config, EngineConfig)
+        self.assertIsInstance(generator.sampling_config, SamplingConfig)
 
         # Test basic fields
-        self.assertEqual(policy.engine_config.model, "test-model-6789")
-        self.assertEqual(policy.engine_config.tensor_parallel_size, 7777)
-        self.assertEqual(policy.engine_config.pipeline_parallel_size, 8888)
-        self.assertTrue(policy.engine_config.enforce_eager)
-        self.assertTrue(policy.engine_config._is_v1_supported_oracle())
+        self.assertEqual(generator.engine_config.model, "test-model-6789")
+        self.assertEqual(generator.engine_config.tensor_parallel_size, 7777)
+        self.assertEqual(generator.engine_config.pipeline_parallel_size, 8888)
+        self.assertTrue(generator.engine_config.enforce_eager)
+        self.assertTrue(generator.engine_config._is_v1_supported_oracle())
 
-        self.assertEqual(policy.sampling_config.n, 1357)
+        self.assertEqual(generator.sampling_config.n, 1357)
         # After __post_init__, guided_decoding becomes GuidedDecodingParams object when True
-        self.assertIsNotNone(policy.sampling_config.guided_decoding)
-        self.assertEqual(policy.sampling_config.max_tokens, 2468)
+        self.assertIsNotNone(generator.sampling_config.guided_decoding)
+        self.assertEqual(generator.sampling_config.max_tokens, 2468)
 
         # Test that engine_dict accepts and preserves nested dict structure
         # The original engine_dict should remain unchanged and accessible
@@ -113,9 +115,9 @@ class TestPolicyConfig(unittest.TestCase):
         _import_error(),
         reason="Import error, likely due to missing dependencies on CI.",
     )
-    def test_policy_yaml_config_loading(self):
-        """Policy can be constructed from a YAML config file."""
-        from forge.actors.policy import Policy
+    def test_generator_yaml_config_loading(self):
+        """Generator can be constructed from a YAML config file."""
+        from forge.actors.generator import Generator
 
         yaml_content = """
         engine_config:
@@ -139,20 +141,20 @@ class TestPolicyConfig(unittest.TestCase):
             with open(f.name, "r") as yaml_file:
                 config = yaml.safe_load(yaml_file)
 
-            policy = Policy(**config)
+            generator = Generator(**config)
 
-            self.assertEqual(policy.engine_config.model, "yaml-test-model-9876")
-            self.assertEqual(policy.engine_config.tensor_parallel_size, 1234)
-            self.assertEqual(policy.engine_config.pipeline_parallel_size, 5678)
-            self.assertTrue(policy.engine_config.enforce_eager)
-            self.assertTrue(policy.engine_config._is_v1_supported_oracle())
+            self.assertEqual(generator.engine_config.model, "yaml-test-model-9876")
+            self.assertEqual(generator.engine_config.tensor_parallel_size, 1234)
+            self.assertEqual(generator.engine_config.pipeline_parallel_size, 5678)
+            self.assertTrue(generator.engine_config.enforce_eager)
+            self.assertTrue(generator.engine_config._is_v1_supported_oracle())
 
-            self.assertEqual(policy.sampling_config.n, 2468)
+            self.assertEqual(generator.sampling_config.n, 2468)
             # After __post_init__, guided_decoding becomes GuidedDecodingParams object when True
-            self.assertIsNotNone(policy.sampling_config.guided_decoding)
-            self.assertEqual(policy.sampling_config.max_tokens, 1357)
+            self.assertIsNotNone(generator.sampling_config.guided_decoding)
+            self.assertEqual(generator.sampling_config.max_tokens, 1357)
 
-            self.assertEqual(policy.available_devices, "yaml-test-device-xyz")
+            self.assertEqual(generator.available_devices, "yaml-test-device-xyz")
 
     @pytest.mark.skipif(
         _import_error(),
@@ -160,7 +162,7 @@ class TestPolicyConfig(unittest.TestCase):
     )
     def test_engineconfig_ignores_invalid_keys(self):
         """EngineConfig.from_dict ignores unexpected keys."""
-        from forge.actors.policy import EngineConfig
+        from forge.actors.generator import EngineConfig
 
         engine_config = {
             "model": "custom-model",


### PR DESCRIPTION
Everything boils down to these simple changes
* `policy.py` => `generator.py` 
* `Policy` => `Generator`

#### But why are there still mentions of `policy` in the repo?

That's because this PR intentionally does **NOT** change the assigned variables themselves. 
A Policy is the concrete concept, and in  this case it's just backed by a particular implementation. The yaml files are untouched for the same reason (it's configuring the Policy, which happens to be this `Generator` under the hood)

``` python
policy: Generator = Generator(...)
```

The `Generator` class has no mentions of policy because it's just a vllm generator (it can be used in other components like a Judge)

#### But what if we want other Generator implementations?

Great, we can rename this class when we actually need to (`VllmGenerator`, `Vllm` doesn't sound terrible)

#### "I don't like the name"

`Generator` > `Policy`, so a different name is not a blocker. 
If anyone gets more than 3 votes on a different name, we'll rename