### PR TITLE
Update spawn_actors API in sft v2 main.py

### DIFF
--- a/apps/sft_v2/llama3_8b.yaml
+++ b/apps/sft_v2/llama3_8b.yaml
@@ -19,8 +19,6 @@ model:
   hf_assets_path: /tmp/Meta-Llama-3.1-8B-Instruct
 
 processes:
-  # scheduler: local # local | mast (not supported yet)
-  # hosts: 1
   procs: 8
   with_gpus: true
 

--- a/apps/sft_v2/main.py
+++ b/apps/sft_v2/main.py
@@ -280,16 +280,16 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
 async def run(cfg: DictConfig) -> None:
     logging.info("Spawing recipe...")
     process_cfg = cfg.pop("processes")
-    recipe = await ForgeSFTRecipe.options(**process_cfg).as_service(cfg)
+    recipe = await ForgeSFTRecipe.options(**process_cfg).as_actor(cfg)
 
     logging.info("Created recipe, running setup.")
-    await recipe.setup.fanout()
+    await recipe.setup.call()
 
     logging.info("Recipe has been setup. Training now.")
-    await recipe.train.fanout()
+    await recipe.train.call()
 
     logging.info("Done training. Clean up")
-    await recipe.cleanup.fanout()
+    await recipe.cleanup.call()
     await recipe.mesh.stop()
     logging.info("All done!")
 


### PR DESCRIPTION
`spawn_actors` has been removed, so updating to use `as_actor` API.

Also some updates to the config to make it work.

Test Plan:
```
python -m apps.sft_v2.main --config apps/sft_v2/llama3_8b.yaml
```
Output:
```
[3] [ForgeSFTRecipe-3/8] 2025-10-03 13:14:24 INFO 91 / 1000|Loss: 1.11570405960083
[1] [ForgeSFTRecipe-1/8] 2025-10-03 13:14:24 INFO 92 / 1000|Loss: 0.9416455030441284
[2] [ForgeSFTRecipe-2/8] 2025-10-03 13:14:24 INFO 92 / 1000|Loss: 1.0203598737716675
[3] [ForgeSFTRecipe-3/8] 2025-10-03 13:14:24 INFO 92 / 1000|Loss: 0.8977944254875183
[6] [ForgeSFTRecipe-6/8] 2025-10-03 13:14:24 INFO 92 / 1000|Loss: 1.0252584218978882
```