### PR TITLE
Monarch/vLLM wheel updates

### DIFF
--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@d56fa2d461286d4b6a19e4ec66b397bf96925989
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
+      test-infra-ref: d56fa2d461286d4b6a19e4ec66b397bf96925989
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@f3246c0ac9467b0af6da391eab7c47fe2a772125
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: f3246c0ac9467b0af6da391eab7c47fe2a772125
+      test-infra-ref: 5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -1,6 +1,7 @@
 name: Build pinned vLLM against PyTorch nightly and upload
 
 on:
+  pull_request:
   push:
     branches:
       - nightly
@@ -13,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@28a1b658404f17c8eabde5f7fe25ae3ac826fae6
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@f3246c0ac9467b0af6da391eab7c47fe2a772125
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: 28a1b658404f17c8eabde5f7fe25ae3ac826fae6
+      test-infra-ref: f3246c0ac9467b0af6da391eab7c47fe2a772125
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: 5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
+      test-infra-ref: ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -1,7 +1,6 @@
 name: Build pinned vLLM against PyTorch nightly and upload
 
 on:
-  pull_request:
   push:
     branches:
       - nightly
@@ -23,6 +22,7 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: d56fa2d461286d4b6a19e4ec66b397bf96925989
       run-smoke-test: false
+      wheel-nightly-policy: gha_workflow_build_preview_wheels_policy
       wheel-upload-path: whl/preview/forge
       package-name: forge
       build-matrix: |

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@d56fa2d461286d4b6a19e4ec66b397bf96925989
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
+      test-infra-ref: d56fa2d461286d4b6a19e4ec66b397bf96925989
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@f3246c0ac9467b0af6da391eab7c47fe2a772125
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: f3246c0ac9467b0af6da391eab7c47fe2a772125
+      test-infra-ref: 5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,6 +1,7 @@
 name: Build nightly wheels and publish to PyTorch Index
 
 on:
+  pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,6 +1,7 @@
 name: Build nightly wheels and publish to PyTorch Index
 
 on:
+  pull_request:
   push:
     branches:
       - nightly
@@ -13,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@28a1b658404f17c8eabde5f7fe25ae3ac826fae6
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@f3246c0ac9467b0af6da391eab7c47fe2a772125
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: 28a1b658404f17c8eabde5f7fe25ae3ac826fae6
+      test-infra-ref: f3246c0ac9467b0af6da391eab7c47fe2a772125
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -14,14 +14,14 @@ permissions:
 jobs:
   build:
     name: forge-cu129-nightly
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
     strategy:
       fail-fast: false
     with:
       repository: meta-pytorch/forge
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: 5fbbaaf26aecc6280f4bc0a812d5cb611944db2a
+      test-infra-ref: ad2d4a86079ce6ae7b181e8e79230bbf38b1c909
       run-smoke-test: false
       wheel-upload-path: whl/preview/forge
       package-name: forge

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,7 +1,6 @@
 name: Build nightly wheels and publish to PyTorch Index
 
 on:
-  pull_request:
   push:
     branches:
       - nightly
@@ -23,6 +22,7 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: d56fa2d461286d4b6a19e4ec66b397bf96925989
       run-smoke-test: false
+      wheel-nightly-policy: gha_workflow_build_preview_wheels_policy
       wheel-upload-path: whl/preview/forge
       package-name: forge
       build-matrix: |

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,7 +1,6 @@
 name: Build nightly wheels and publish to PyTorch Index
 
 on:
-  pull_request:
   push:
     branches:
       - nightly


### PR DESCRIPTION
Changes to disable smoke test and update permission group for AWS upload of wheels for our CI