### PR TITLE
[Debugging] Create a stand alone trainer app

### DIFF
--- a/apps/rl_trainer/main.py
+++ b/apps/rl_trainer/main.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Usage: python -m apps.trainer.main --config apps/grpo/qwen3_32b.yaml
+# Usage: python -m apps.rl_trainer.main --config apps/grpo/qwen3_32b.yaml
 
 import asyncio
 


### PR DESCRIPTION
Very similar to the stand-alone vllm app, this trainer app is introduced to make investigating trainer OOM faster. This could be very useful for single-node trainer because you can run it locally and the system metrics are much easier to obtain.

## Test
Change the activation checkpointing config in `apps/grpo/qwen3_32b.yaml` and reproduce the OOM.  

```
  activation_checkpoint:
    mode: selective
    selective_ac_option: op
```
The repro is blazingly fast :) 

https://meta.wandb.io/jiyue/grpo-training/runs/8qe73q1b?nw=nwuserjiyue


