### PR TITLE
Add a check to not build docs in forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-docs:
+    if: github.repository_owner == 'meta-pytorch'
     name: Build Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Just a small QOL change to not run `build-docs` in forks - should prevent `deploy-docs` from running and sending an email on failure whenever main is synced.