### PR TITLE
Test for vanilla vLLM vs Forge Policy on correctness

### DIFF
--- a/tests/integration_tests/test_vllm_policy_same_output.py
+++ b/tests/integration_tests/test_vllm_policy_same_output.py
@@ -52,7 +52,7 @@ async def main():
         vllm_model = AsyncLLM.from_engine_args(args)
 
         # Setup Policy service
-        # TODO: Remove metric logger instantiation after X lands
+        # TODO: Remove metric logger instantiation after https://github.com/meta-pytorch/forge/pull/303 lands
         mlogger = await get_or_create_metric_logger()
         await mlogger.init_backends.call_one({"console": {"log_per_rank": False}})
 


### PR DESCRIPTION
### Context

We don't have any tests confirming that vLLM output matches our Forge Policy output. It should b/c we build upon vLLM; however, we are doing custom logic so we should check

### How to run

```python tests/integration_tests/test_vllm_policy_same_output.py```

You should see output like:

```
✅ Outputs are the same!
```

### FAQs

1. **Why isn't this just a normal test?** Great question: for starters we don't have GPU runners in CI yet (cc @allenwang28  @ebsmothers to have fixed soon!) and also there's some Monarch errors that obscure this from running properly in pytest. That should also be fixed eventually. I will be filing a follow up ticket to convert this to a test that runs on every merge to main.
2. I'm hoping 1) is the only question.