### PR TITLE
Fix conversion for Guided decoding

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -99,6 +99,12 @@ class SamplingConfig:
         valid_args = {k: v for k, v in d.items() if k in all_fields}
         return cls(**valid_args)
 
+    def asdict(self):
+        # Use the full object instead of a Dict
+        ret = asdict(self)
+        ret["guided_decoding"] = self.guided_decoding
+        return ret
+
 
 @dataclass
 class EngineConfig(EngineArgs):
@@ -254,7 +260,7 @@ class Policy(PolicyInterface):
 
         # Setup sampling params
         self.sampling_params = get_default_sampling_params(
-            self.vllm_config, overrides=asdict(self.sampling_config)
+            self.vllm_config, overrides=self.sampling_config.asdict()
         )
 
         # Setup processors


### PR DESCRIPTION
`guided_decoding` was getting recursively deconstructed. This keeps the object class
```
HF_HUB_DISABLE_XET=1 python -m tests.sandbox.vllm.main --config tests/sandbox/vllm/llama3_8b.yaml
```
With guided_decoding on:
<img width="579" height="100" alt="image" src="https://github.com/user-attachments/assets/5ff51dfc-d3d0-45cf-b8c5-1555a2398b7b" />
