### PR TITLE
Fix test_policy_config after refactor to EngineArgs

### DIFF
--- a/src/forge/actors/policy.py
+++ b/src/forge/actors/policy.py
@@ -83,7 +83,7 @@ class Policy(PolicyInterface):
 
         if isinstance(self.engine_args, Mapping):
             self.engine_args = EngineArgs(**self.engine_args)
-            self.engine_args._is_v1_supported_oracle = lambda *_: True
+        self.engine_args._is_v1_supported_oracle = lambda *_: True
 
         if isinstance(self.sampling_params, Mapping):
             self.sampling_params = SamplingParams.from_optional(**self.sampling_params)

--- a/tests/unit_tests/test_policy_config.py
+++ b/tests/unit_tests/test_policy_config.py
@@ -42,7 +42,7 @@ class TestPolicyConfig(unittest.TestCase):
         self.assertIsNone(policy.available_devices)
 
         # Worker defaults
-        self.assertEqual(policy.engine_args.model, "meta-llama/Llama-3.1-8B-Instruct")
+        self.assertEqual(policy.engine_args.model, "Qwen/Qwen3-0.6B")
         self.assertEqual(policy.engine_args.tensor_parallel_size, 1)
         self.assertEqual(policy.engine_args.pipeline_parallel_size, 1)
         self.assertFalse(policy.engine_args.enforce_eager)
@@ -51,7 +51,7 @@ class TestPolicyConfig(unittest.TestCase):
         # Sampling defaults
         self.assertEqual(policy.sampling_params.n, 1)
         self.assertFalse(policy.sampling_params.guided_decoding)
-        self.assertEqual(policy.sampling_params.max_tokens, 512)
+        self.assertEqual(policy.sampling_params.max_tokens, 16)
 
     @pytest.mark.skipif(
         _import_error(),
@@ -69,11 +69,8 @@ class TestPolicyConfig(unittest.TestCase):
             "tensor_parallel_size": 7777,
             "pipeline_parallel_size": 8888,
             "enforce_eager": True,
-            "nested_config": {
-                "gpu_memory_utilization": 0.9,
-                "max_model_len": 4096,
-                "custom_settings": {"temperature": 0.7, "top_p": 0.9},
-            },
+            "gpu_memory_utilization": 0.9,
+            "max_model_len": 4096,
         }
 
         sampling_dict = {
@@ -94,21 +91,13 @@ class TestPolicyConfig(unittest.TestCase):
         self.assertEqual(policy.engine_args.model, "test-model-6789")
         self.assertEqual(policy.engine_args.tensor_parallel_size, 7777)
         self.assertEqual(policy.engine_args.pipeline_parallel_size, 8888)
+        self.assertEqual(policy.engine_args.gpu_memory_utilization, 0.9)
+        self.assertEqual(policy.engine_args.max_model_len, 4096)
         self.assertTrue(policy.engine_args.enforce_eager)
         self.assertTrue(policy.engine_args._is_v1_supported_oracle())
 
         self.assertEqual(policy.sampling_params.n, 1357)
         self.assertEqual(policy.sampling_params.max_tokens, 2468)
-
-        # Test that engine_dict accepts and preserves nested dict structure
-        # The original engine_dict should remain unchanged and accessible
-        self.assertIn("nested_config", engine_dict)
-        self.assertEqual(engine_dict["nested_config"]["gpu_memory_utilization"], 0.9)
-        self.assertEqual(engine_dict["nested_config"]["max_model_len"], 4096)
-        self.assertEqual(
-            engine_dict["nested_config"]["custom_settings"]["temperature"], 0.7
-        )
-        self.assertEqual(engine_dict["nested_config"]["custom_settings"]["top_p"], 0.9)
 
     @pytest.mark.skipif(
         _import_error(),


### PR DESCRIPTION
Minor fixes after the refactor to EngineArgs in https://github.com/meta-pytorch/forge/pull/381. Specifically, changing the defaults and removing nested instantiation support

---
Before (Other errors show up as the ones listed get fixed)
<img width="890" height="84" alt="image" src="https://github.com/user-attachments/assets/08883ac3-9543-4063-b5dd-68c493f6e621" />

After
<img width="890" height="146" alt="image" src="https://github.com/user-attachments/assets/d6fb87cb-5151-44f6-b625-32e6179aa215" />
