### PR TITLE
Final SLURM fixes

### DIFF
--- a/src/forge/controller/provisioner.py
+++ b/src/forge/controller/provisioner.py
@@ -289,16 +289,10 @@ class Provisioner:
                 for env_var in all_env_vars():
                     env_vars[env_var.name] = str(env_var.get_value())
 
-            if MONARCH_HOSTMESH_V1.get_value():
-                procs = host_mesh.spawn_procs(
-                    per_host={"procs": num_procs},
-                    setup=functools.partial(bootstrap, env=env_vars),
-                )
-            else:
-                procs = host_mesh.spawn_procs(
-                    per_host={"procs": num_procs},
-                    bootstrap=functools.partial(bootstrap, env=env_vars),
-                )
+            procs = host_mesh.spawn_procs(
+                per_host={"procs": num_procs},
+                bootstrap=functools.partial(bootstrap, env=env_vars),
+            )
 
             if is_remote:
                 await self.launcher.remote_setup(procs)

--- a/src/forge/env.py
+++ b/src/forge/env.py
@@ -100,7 +100,7 @@ MONARCH_MAX_FRAME_LENGTH = EnvVar(
 )
 
 MONARCH_HOSTMESH_V1 = EnvVar(
-    name="MONARCH_HOSTMESH_V1",
+    name="MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE",
     default=False,
     description="Whether or not to use Monarch's experimental hostmesh v1 APIs",
 )


### PR DESCRIPTION
it seems with the Monarch pin update, we need to use
```
MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE
```

rather than
```
MONARCH_HOSTMESH_V1
```

Additionally, spawn_procs APIs match now. Tomorrow we can probably just remove the V1 path altogether, but keeping it for now just to make sure things are working.

With this, I see that SLURM 32B works:

```
MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1 TORCHSTORE_RDMA_ENABLED=1 python -m apps.grpo.main --config=apps/grpo/qwen3_32b.yaml
```

Note:

```
  rl_trainer_perf/push_weights/ts_save/duration_avg_s: 9.150277181121055
  rl_trainer_perf/push_weights/ts_save/duration_max_s: 9.425452718045563
  policy_worker_perf/update_weights/total_duration_avg_s: 77.36585016347817
  policy_worker_perf/update_weights/total_duration_max_s: 88.17838381230831
```

