### PR TITLE
integrate version.sh into wheel build jobs

### DIFF
--- a/.github/workflows/build_vllm.yaml
+++ b/.github/workflows/build_vllm.yaml
@@ -1,7 +1,6 @@
 name: Build pinned vLLM against PyTorch nightly and upload
 
 on:
-  pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,7 +1,6 @@
 name: Build nightly wheels and publish to PyTorch Index
 
 on:
-  pull_request:
   push:
     branches:
       - nightly


### PR DESCRIPTION


Needed to build the latest Monarch wheels to get around import errors in #334

Test plan:
<img width="567" height="716" alt="Screenshot 2025-10-14 at 7 17 20 AM" src="https://github.com/user-attachments/assets/ab421c3f-7e4d-46b7-9556-869e5697cd4f" />
