### PR TITLE
Configurable ReplayBuffer

### DIFF
--- a/src/forge/actors/replay_buffer.py
+++ b/src/forge/actors/replay_buffer.py
@@ -29,8 +29,8 @@ class BufferEntry:
 
 def age_evict(
     buffer: deque, policy_version: int, max_samples: int = None, max_age: int = None
-):
-    """Default buffer eviction policy"""
+) -> list[int]:
+    """Buffer eviction policy, remove old or over-sampled entries"""
     indices = []
     for i, entry in enumerate(buffer):
         if max_age and policy_version - entry.data.policy_version > max_age:
@@ -41,8 +41,8 @@ def age_evict(
     return indices
 
 
-def random_sample(buffer: deque, sample_size: int, policy_version: int):
-    """Default buffer sampling policy"""
+def random_sample(buffer: deque, sample_size: int, policy_version: int) -> list[int]:
+    """Buffer random sampling policy"""
     if sample_size > len(buffer):
         return None
     return random.sample(range(len(buffer)), k=sample_size)

--- a/tests/unit_tests/test_replay_buffer.py
+++ b/tests/unit_tests/test_replay_buffer.py
@@ -124,3 +124,16 @@ class TestReplayBuffer:
             assert len(dp_samples) == 2  # batch_size
 
         replay_buffer.clear.call_one().get()
+
+    @pytest.mark.asyncio
+    async def test_collect(self) -> None:
+        """Test _collect method"""
+        local_rb = ReplayBuffer(batch_size=1)
+        await local_rb.setup._method(local_rb)
+        for i in range(1, 6):
+            local_rb.buffer.append(i)
+        values = local_rb._collect([2, 0, -1])
+        assert values == [3, 1, 5]
+        values = local_rb._collect([1, 3])
+        assert values == [2, 4]
+        assert local_rb.buffer[0] == 1


### PR DESCRIPTION
Added custom Sample and Eviction policies to Replay buffer. Our existing replay buffer did not allow for custom handling of these two properties which are important for tuning async training runs. To allow these functions to be generic and user defined, I added two callable inputs, sample_policy and eviction_policy, they take in the current buffer, some buffer parameters (max_policy_age, max_resample_count) and return a list of indices to either evict or sample. An list of indices is returned instead of directly modifying the buffer so we can control how the buffer is updated ourself instead of the user.

Changelog:
- BufferEntry type created to track episode sample_counts. This allows for user control over how often data can be resampled
- default_evict and default_sample are default policies that match the existing behavior of the ReplayBuffer
- max_buffer_size added with a first in first out policy for removing old data (the assumption is that stale data will have already been removed by evict
- max_policy_age, max_resample_count, and max_buffer_size all support a None option now to remove this restriction
- buffer changed from list to deque. This allows for efficient enforcement of max_buffer_size without constant reallocation of the entire buffer.
- _collect method added to get the buffer entries given a list of indices. Needs special handling to do this efficiently with a deque object.
- calling sample no longer removes sampled data from the buffer, is just increments the sample count for that data. It's up to the eviction policy to remove data based on sample count.
- removed buffer_size parameter from sample to simplify api
- updated unit_test for api changes and slight behavior change in when sampled data is removed.

