### PR TITLE
hardcode refmodel.checkpoint.folder to empty

### DIFF
--- a/src/forge/actors/reference_model.py
+++ b/src/forge/actors/reference_model.py
@@ -87,7 +87,11 @@ class ReferenceModel(ForgeActor):
     @endpoint
     async def setup(self):
         engine_config = {f.name: getattr(self, f.name) for f in fields(self)}
-        self.engine = ForgeEngine(ForgeJobConfig(**engine_config))
+        engine_config = ForgeJobConfig(**engine_config)
+        engine_config.checkpoint.folder = (
+            ""  # hardcode to empty to force load from initial_load_path
+        )
+        self.engine = ForgeEngine(engine_config)
         self.engine.checkpointer.load()
         self.model = self.engine.model_parts[0]  # No pipeline parallelism yet
         self.model.eval()


### PR DESCRIPTION
Solving https://github.com/meta-pytorch/forge/issues/413

After this, the checkpoint for reference model will be load only from  [`initial_load_path`](https://github.com/meta-pytorch/forge/blob/main/apps/grpo/qwen3_1_7b.yaml#L112). User still have the flexibility to change ref model by modifying `initial_load_path`.


Tested on grpo/main. `ref_model` now will always load from the `initial_load_path` regardless of trainer's checkpoint config.

