### PR TITLE
Remove use_dcp option in qwen3_8b

### DIFF
--- a/apps/grpo/qwen3_8b.yaml
+++ b/apps/grpo/qwen3_8b.yaml
@@ -41,7 +41,6 @@ policy:
 
 # Trainer configuration
 trainer:
-  use_dcp: true
   model:
     name: qwen3
     flavor: 8B


### PR DESCRIPTION
This seems to be unintended. `use_dcp: True` is removed in both 1.7b and 32b.