### PR TITLE
mark vLLM policy integration tests as async

### DIFF
--- a/tests/integration_tests/test_vllm_policy_correctness.py
+++ b/tests/integration_tests/test_vllm_policy_correctness.py
@@ -97,9 +97,7 @@ async def test_same_output():
         for vllm_output, policy_output in zip(vllm_outputs, policy_outputs):
             assert vllm_output != ""
             assert policy_output != ""
-            if vllm_output != policy_output:
-                print(f"❌ Got different results: {vllm_output} vs. {policy_output}")
-        print("✅ Outputs are the same!")
+            assert vllm_output == policy_output
 
     finally:
         if policy is not None:
@@ -234,10 +232,7 @@ async def test_cache_usage():
         for vllm_output, policy_output in zip(vllm_outputs, policy_outputs):
             assert vllm_output != ""
             assert policy_output != ""
-            if vllm_output != policy_output:
-                print(f"❌ Got different results: {vllm_output} vs. {policy_output}")
-
-        print("\n✅ Prefix cache usage is the same!")
+            assert vllm_output == policy_output
 
     finally:
         if policy is not None:


### PR DESCRIPTION
Addresses part of #411

Before:

```
pytest tests/integration_tests/test_vllm_policy_correctness.py
...
FAILED tests/integration_tests/test_vllm_policy_correctness.py::test_same_output - Failed: async def functions are not natively supported.
FAILED tests/integration_tests/test_vllm_policy_correctness.py::test_cache_usage - Failed: async def functions are not natively supported.
========== 2 failed in 4.71s ============
```

After:

```
pytest tests/integration_tests/test_vllm_policy_correctness.py
...
========== 2 passed in 84.36s (0:01:24) ================
```