### PR TITLE
fix wandb config

### DIFF
--- a/src/forge/observability/metrics.py
+++ b/src/forge/observability/metrics.py
@@ -13,11 +13,11 @@ from enum import Enum
 from typing import Any
 
 import pytz
+from monarch.actor import context, current_rank
 
 from forge.observability.utils import get_proc_name_with_rank
 
 from forge.util.logging import log_once
-from monarch.actor import context, current_rank
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary:
Current wandb config is hard-coded to only take `project`,and `group`, as shown in this [line](https://github.com/meta-pytorch/torchforge/blob/d464193e1f618c0177c98dc137665a987b7831cd/src/forge/observability/metrics.py#L737) and the other configs like `entity` is totally ignored. This PR fixed this issue and allow other arguments to be passed into wandb config.

## Test Plan:
### with `entity`:
Run this following training `python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml` with  configs like:
```
# Observability configuration
metric_logging:
  wandb:
    entity: torchforge
    project: "kaiwu-coding-grpo"
    reduce_across_ranks: True
  console:
    reduce_across_ranks: True
```

saw the log: 
```
wandb: 
wandb: 🚀 View run smart-bush-1 at: https://meta.wandb.io/torchforge/kaiwu-coding-grpo/runs/8bf85azv
wandb: Find logs at: wandb/run-20251020_101829-8bf85azv/logs
```

### without `entity`
removing the entity from config:
```
metric_logging:
  wandb:
    project: "kaiwu-coding-grpo"
    reduce_across_ranks: True
  console:
    reduce_across_ranks: True
```

training is running and now saw :
```
wandb: Tracking run with wandb version 0.22.2
wandb: Run data is saved locally in /home/kaiwu/work/kaiwu/forge/wandb/run-20251020_105711-hcazo06j
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run dark-energy-11
wandb: ⭐️ View project at https://meta.wandb.io/kaiwu/kaiwu-coding-grpo
wandb: 🚀 View run at https://meta.wandb.io/kaiwu/kaiwu-coding-grpo/runs/hcazo06j
```