### PR TITLE
Use smaller runner for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
   build-docs:
     if: github.repository_owner == 'meta-pytorch'
     name: Build Documentation
-    runs-on: linux.2xlarge
+    runs-on: linux.4xlarge
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
The docs build only needs to import Python modules for Sphinx autodoc, not execute GPU code. Change from linux.g5.4xlarge.nvidia.gpu to linux.large for better availability and faster queue times.