### PR TITLE
Fix learning rate logging when using LRSchedulersContainer

### DIFF
--- a/src/forge/actors/trainer.py
+++ b/src/forge/actors/trainer.py
@@ -166,11 +166,7 @@ class RLTrainer(ForgeActor):
 
         t.step("forward_backward")
 
-        current_lr = (
-            self.engine.lr_schedulers.get_last_lr()[0]
-            if hasattr(self.engine.lr_schedulers, "get_last_lr")
-            else 0.001
-        )
+        current_lr = self.engine.lr_schedulers.schedulers[0].get_last_lr()[0]
         record_metric("rl_trainer/learning_rate", current_lr, Reduce.MIN)
 
         self.engine.optimizers.step()


### PR DESCRIPTION

Now the lr starts from 1e-05 (specified in the config) instead of 0.001

Log: 
```
rl_trainer/learning_rate: 1e-05
```

<img width="330" height="296" alt="image" src="https://github.com/user-attachments/assets/649c3ab1-1cc5-4c1f-899f-a00774eb654c" />
