### PR TITLE
[sft] load chat_template.jinja if available

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -155,7 +155,13 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
                 self.job_config.model.hf_assets_path, "generation_config.json"
             ),
             chat_template_path=(
-                path if os.path.exists(path := os.path.join(self.job_config.model.hf_assets_path, "chat_template.jinja")) else None
+                path
+                if os.path.exists(
+                    path := os.path.join(
+                        self.job_config.model.hf_assets_path, "chat_template.jinja"
+                    )
+                )
+                else None
             ),
         )
 


### PR DESCRIPTION
Add support for loading `chat_template.jinja` in HuggingFaceModelTokenizer.

If the file is missing, fall back to using `chat_template` in tokenizer_config.json.

Ref: https://github.com/huggingface/transformers/pull/33957