### PR TITLE
Fix: Convert has_fetcher and get_fetcher_count to async

### DIFF
--- a/src/forge/observability/metric_actors.py
+++ b/src/forge/observability/metric_actors.py
@@ -437,12 +437,12 @@ class GlobalLoggingActor(ForgeActor):
                 await backend.log_batch(reduced_metrics, global_step)
 
     @endpoint
-    def has_fetcher(self, proc_id: str) -> bool:
+    async def has_fetcher(self, proc_id: str) -> bool:
         """Check if a fetcher is registered with the given proc_id."""
         return proc_id in self.fetchers
 
     @endpoint
-    def get_fetcher_count(self) -> int:
+    async def get_fetcher_count(self) -> int:
         return len(self.fetchers)
 
     @endpoint


### PR DESCRIPTION
Monarch actors require all endpoints to be either sync or async, not mixed. This change makes has_fetcher and get_fetcher_count async to match other endpoints in GlobalLoggingActor, preventing actor deadlock errors.