### PR TITLE
Fix: Enable multi-epoch training by restarting dataset iterator

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -242,28 +242,27 @@ class DatasetActor(ForgeActor):
 
     @endpoint
     async def sample(self) -> dict[str, str] | None:
-        while True:
-            try:
-                sample = next(self._iterator)
+        try:
+            sample = next(self._iterator)
 
-                record_metric("dataset/sample/count_samples_generated", 1, Reduce.SUM)
-                record_metric(
-                    "dataset/sample/avg_sample_len",
-                    len(sample["request"]),
-                    Reduce.MEAN,
-                )
-                record_metric("dataset/sample/current_epoch", self._epoch, Reduce.MAX)
+            record_metric("dataset/sample/count_samples_generated", 1, Reduce.SUM)
+            record_metric(
+                "dataset/sample/avg_sample_len",
+                len(sample["request"]),
+                Reduce.MEAN,
+            )
+            record_metric("dataset/sample/current_epoch", self._epoch, Reduce.MAX)
 
-                return sample
-            except StopIteration:
-                # Restart iterator for next epoch with reshuffling
-                self._epoch += 1
-                print(
-                    f"Dataset epoch {self._epoch - 1} completed. Starting epoch {self._epoch}"
-                )
-                self._base_dataset.set_epoch(self._epoch)
-                self._iterator = iter(self._base_dataset)
-                # Continue loop to get next sample from restarted iterator
+            return sample
+        except StopIteration:
+            # Restart iterator for next epoch with reshuffling
+            self._epoch += 1
+            print(
+                f"Dataset epoch {self._epoch - 1} completed. Starting epoch {self._epoch}"
+            )
+            self._base_dataset.set_epoch(self._epoch)
+            self._iterator = iter(self._base_dataset)
+            return next(self._iterator)
 
     @endpoint
     async def pad_token(self):


### PR DESCRIPTION
## Summary
Fixes training stopping after first epoch. The dataset iterator now restarts when exhausted, enabling multi-epoch training.

## Changes
- Store base dataset reference to allow iterator recreation
- Restart iterator on `StopIteration` instead of returning `None`
- Add epoch tracking and logging for visibility

## Test plan
- Run GRPO training and verify it continues beyond the first epoch
- Check logs for epoch completion messages

Tested with a subset of 50 samples.

<img width="1101" height="345" alt="image" src="https://github.com/user-attachments/assets/2055ad55-0647-4c58-99bd-49c4c5181f1a" />
