### PR TITLE
[DOCS] Fix race condition in getting_started.md example script

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -124,6 +124,7 @@ After installation, verify that all components are working correctly:
 
    # Test basic Monarch functionality
    procs = this_host().spawn_procs({'gpus': 1})
+   procs.initialized.get()
    print('Monarch: Process spawning works')
    "
    ```


### PR DESCRIPTION
## Summary
Updates the Monarch test script in getting_started.md to prevent an ungraceful shutdown.
This is achieved by calling `procs.initialized.get()`, which blocks the main script and forces it to wait for the worker processes to finish initializing.

## Motivation
The original script was susceptible to a race condition. The main script would often exit before the background thread had finished its work, resulting in a Fatal Python error: PyGILState_Release, as the background thread would attempt to interact with a Python runtime context that had already been destroyed.

Since this script is one of the first entry points for new users, it is critical that it runs robustly.
```shell
python -c "
from monarch.actor import Actor, this_host

# Test basic Monarch functionality
procs = this_host().spawn_procs({'gpus': 1})
print('Monarch: Process spawning works')
"
Monarch: Process spawning works
Fatal Python error: PyGILState_Release: thread state 0x7efb0c06c380 must be current when releasing
Python runtime state: finalizing (tstate=0x00000000008a9518)

Thread 0x00007eff9412a400 (most recent call first):
  <no Python frame>

Extension modules: numpy._core._multiarray_umath, numpy.linalg._umath_linalg, torch._C, torch._C._dynamo.autograd_compiler, torch._C._dynamo.eval_frame, torch._C._dynamo.guards, torch._C._dynamo.utils, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn, torch._C._sparse, torch._C._special (total: 13)
```

## Test plan
Local testing confirms the race condition is fixed. No CI test plan yet as we do not run doctests for markdown files now.