### PR TITLE
use eos_token_id if there is no pad_token_id to avoid sending None

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -266,7 +266,12 @@ class DatasetActor(ForgeActor):
 
     @endpoint
     async def pad_token(self):
-        return self._tokenizer.pad_token_id
+        # Use pad_token_id if available, otherwise use eos_token_id
+        # Llama models don't have a pad token by default
+        if self._tokenizer.pad_token_id is not None:
+            return self._tokenizer.pad_token_id
+        else:
+            return self._tokenizer.eos_token_id
 
 
 async def drop_weights(version: int):


### PR DESCRIPTION
Some models, like Llama models, did not have `pad_token_id `thus this [pad_token()](https://github.com/meta-pytorch/torchforge/blob/main/apps/grpo/main.py#L269) will return None, which cause the training failure.  This PR will use `eos_token_id` if there is no `pad_token_id` to avoid that. 