### PR TITLE
Give MAST jobs a more descriptive name based on the name of the config being launched

### DIFF
--- a/.meta/mast/launch.sh
+++ b/.meta/mast/launch.sh
@@ -36,7 +36,6 @@ CONFIG_FILE="$1"
 
 # Generate a unique job name based on the config file name
 BASENAME=$(basename "$CONFIG_FILE" .yaml)
-BASENAME=${BASENAME#.meta/mast/}
 RANDOM_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1)
 JOB_NAME="${BASENAME}-${RANDOM_SUFFIX}"
 log_info "Generated job name: $JOB_NAME"


### PR DESCRIPTION
This will make it easier to tell what a MAST job is running.

Before, MAST jobs looked like: `daniellepintz-forge-tw3pdn`

After, they look like:
<img width="681" height="52" alt="Screenshot 2025-11-09 at 1 54 12 PM" src="https://github.com/user-attachments/assets/088f4148-c2a3-4bb9-a53d-30f66d6f23b7" />

https://www.internalfb.com/mlhub/pipelines/runs/mast/qwen3_32b_mast-ugj9cm