### PR TITLE
[easu][fix] make method async

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -210,7 +210,7 @@ class DatasetActor(ForgeActor):
     model: str = "Qwen/Qwen3-1.7B"
 
     @endpoint
-    def setup(self):
+    async def setup(self):
         self._tokenizer = get_tokenizer(self.model)
         self._epoch = 0
 


### PR DESCRIPTION
```ValueError: <class 'abc.DatasetActor'> mixes both async and sync endpoints.Synchronous endpoints cannot be mixed with async endpoints because they can cause the asyncio loop to deadlock if they wait.sync: ['setup'] async: ['pad_token', 'sample']```