### PR TITLE
Metric logger

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -127,7 +127,6 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
 
     @endpoint
     async def setup(self):
-        # Setup training data
         self.train_dataloader = self.setup_data()
 
         self.mlogger = await self.setup_metric_logger()


### PR DESCRIPTION
Fixing this issue here: https://github.com/meta-pytorch/torchforge/issues/553

## Problem
- Calling `get_or_create_metric_logger()` inside actors fails with: `AttributeError: NYI: attempting to get ProcMesh attribute 'slice' on object that's actually a ProcMeshRef`
- `this_proc()` returns `ProcMeshRef` (proxy) instead of `ProcMesh` (actual mesh) in actor contexts
- Loss metrics were recorded but never flushed to WandB

## Solution
- Use `get_or_spawn_controller("global_logger", GlobalLoggingActor)` to get reference to the existing global logger
- Avoids calling `this_proc()` which fails in actor contexts
- Retrieves the singleton controller by name without triggering ProcMeshRef errors

## Changes
- Updated `setup_metric_logger()` to use `get_or_spawn_controller()` instead of `get_or_create_metric_logger()`
- Added imports: `GlobalLoggingActor` and `get_or_spawn_controller`