### PR TITLE
Revert "Metric logger"

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -28,10 +28,9 @@ from forge.data.datasets.packed import PackedDataset, TextPacker
 from forge.data.datasets.sft_dataset import AlpacaToMessages, sft_iterable_dataset
 from forge.data.tokenizer import HuggingFaceModelTokenizer
 from forge.observability import get_or_create_metric_logger, record_metric, Reduce
-from forge.observability.metric_actors import GlobalLoggingActor
 from forge.util.config import parse
 
-from monarch.actor import current_rank, current_size, endpoint, get_or_spawn_controller
+from monarch.actor import current_rank, current_size, endpoint
 from omegaconf import DictConfig, OmegaConf
 from torch import nn
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -111,12 +110,8 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
         logger.info("env: {}".format(env))
 
     async def setup_metric_logger(self):
-        """Retrieve the already-initialized metric logger from main process"""
-
-        # The global logger was already created in main process.
-        # Use get_or_spawn_controller from monarch to get reference to it
-        # Get reference to the existing global logger (don't create new one)
-        mlogger = await get_or_spawn_controller("global_logger", GlobalLoggingActor)
+        """Initialization happens in the main process. Here we just retrieve it"""
+        mlogger = await get_or_create_metric_logger()
         return mlogger
 
     def record_batch_metrics(self, data_metrics: list):
@@ -128,7 +123,6 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
     @endpoint
     async def setup(self):
         self.train_dataloader = self.setup_data()
-
         self.mlogger = await self.setup_metric_logger()
 
         # self.train_dataloader = self.setup_data(


### PR DESCRIPTION
Reverts meta-pytorch/torchforge#554

I mistakenly thought it was broken on my end too with the newest build. I tested in main and things are working fine. The original error was because of an old monarch version. This PR is not necessary.