### PR TITLE
Fix truthiness bug
  in age_evict

### DIFF
--- a/src/forge/actors/replay_buffer.py
+++ b/src/forge/actors/replay_buffer.py
@@ -33,9 +33,9 @@ def age_evict(
     """Buffer eviction policy, remove old or over-sampled entries"""
     indices = []
     for i, entry in enumerate(buffer):
-        if max_age and policy_version - entry.data.policy_version > max_age:
+        if max_age is not None and policy_version - entry.data.policy_version > max_age:
             continue
-        if max_samples and entry.sample_count >= max_samples:
+        if max_samples is not None and entry.sample_count >= max_samples:
             continue
         indices.append(i)
     return indices


### PR DESCRIPTION
Fix bug in age_evict() where max_age=0 and max_samples=0 are incorrectly treated as falsy
  values. This is buggy for pure on-policy training (max_age=0). Changed to use explicit None checks instead of
  truthiness checks.