### PR TITLE
_init_dist() removal

### DIFF
--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -85,7 +85,7 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
 
     async def setup_metric_logger(self):
         """Initialization happens in the main process. Here we just retrieve it"""
-        mlogger: GlobalLoggingActor = await get_or_create_metric_logger()
+        mlogger = await get_or_create_metric_logger()
         return mlogger
 
     def record_batch_metrics(self, data_metrics: list):


### PR DESCRIPTION
The _init_dist() method was setting up PyTorch distributed environment
variables manually. This is no longer needed because the provisioner's
get_proc_mesh() method now properly calls setup_env_for_distributed()
from Monarch, which handles all distributed environment setup. This simplifies the code and removes redundant initialization.