### PR TITLE
wandb hack

### DIFF
--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -17,23 +17,3 @@ try:
         os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 except ImportError:
     pass
-
-
-# FIXME: remove this once wandb fixed this issue
-# https://github.com/wandb/wandb/issues/10890
-# Patch importlib.metadata.distributions before wandb imports it
-# to filter out packages with None metadata
-import importlib.metadata
-
-# Guard to ensure this runs only once
-if not hasattr(importlib.metadata, "_distributions_patched"):
-    _original_distributions = importlib.metadata.distributions
-
-    def _patched_distributions():
-        """Filter out distributions with None metadata"""
-        for dist in _original_distributions():
-            if dist.metadata is not None:
-                yield dist
-
-    importlib.metadata.distributions = _patched_distributions
-    importlib.metadata._distributions_patched = True

--- a/src/forge/util/logging.py
+++ b/src/forge/util/logging.py
@@ -4,6 +4,25 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# FIXME: remove this once wandb fixed this issue
+# https://github.com/wandb/wandb/issues/10890
+# Patch importlib.metadata.distributions before wandb imports it
+# to filter out packages with None metadata
+import importlib.metadata
+
+# Guard to ensure this runs only once
+if not hasattr(importlib.metadata, "_distributions_patched"):
+    _original_distributions = importlib.metadata.distributions
+
+    def _patched_distributions():
+        """Filter out distributions with None metadata"""
+        for distribution in _original_distributions():
+            if distribution.metadata is not None:
+                yield distribution
+
+    importlib.metadata.distributions = _patched_distributions
+    importlib.metadata._distributions_patched = True
+
 import logging
 from functools import lru_cache
 


### PR DESCRIPTION
Summary:
Fixes wandb complaining about metadata being None.

tested by running
python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml

Differential Revision: D87092141


