### PR TITLE
fix: use correct import alias for hyperactor

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -129,7 +129,7 @@ class Slurmlauncher(BaseLauncher):
         configure(default_transport=ChannelTransport.Tcp)
 
     async def get_allocator(self, name: str, num_hosts: int) -> tuple[Any, Any, str]:
-        appdef = hyperactor.host_mesh(
+        appdef = meta_hyperactor.host_mesh(
             image="test", meshes=[f"{name}:{num_hosts}:gpu.small"]
         )
         for role in appdef.roles:


### PR DESCRIPTION
Fixes a bug where the `hyperactor` module was imported with an alias, but referenced incorrectly