### PR TITLE
Fix SLURM Launcher: Add Hyperactor Import and Use TcpWithHostname Transport

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -127,7 +127,6 @@ class Slurmlauncher(BaseLauncher):
         # HostMesh currently requires explicit configuration
         # of the underlying transport from client to mesh.
         # This can be removed in the future once this has been removed.
-        # Changed TCP this to TcpWithHostname for the slurm launcher
         configure(default_transport=ChannelTransport.TcpWithHostname)
 
     async def get_allocator(self, name: str, num_hosts: int) -> tuple[Any, Any, str]:


### PR DESCRIPTION

### Changes

1.  **Added missing hyperactor import** (line 28)
    
    *   `from monarch.tools.components import hyperactor`
    *   Required for `hyperactor.host_mesh()` call in `get_allocator()`
2.  **Changed SLURM transport to TcpWithHostname** (line 131)
    
    *   Changed from `ChannelTransport.Tcp` to `ChannelTransport.TcpWithHostname`
    *   Fixes connectivity issues in SLURM multi-node environments where hostname resolution is required