### PR TITLE
Clean up setting of env vars in `client_bootstrap.sh`

### DIFF
--- a/.meta/mast/client_bootstrap.sh
+++ b/.meta/mast/client_bootstrap.sh
@@ -41,11 +41,5 @@ fi
 
 cd "$WORKSPACE_DIR/forge"
 
-export WANDB_MODE=offline
-export HF_HUB_OFFLINE=1
-export MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1
-export TORCHSTORE_RDMA_ENABLED=1
-export HF_HOME=/mnt/wsfuse/teamforge/hf
-
 # Execute the client training script with all passed arguments
 exec python -X faulthandler .meta/mast/main.py "$@"


### PR DESCRIPTION
These env vars are already set in launcher.py:

https://github.com/meta-pytorch/torchforge/blob/f6e71760917d2dde3f58af1a43e567da513fc77c/src/forge/controller/launcher.py#L289-L301

# Test Plan
```
./.meta/mast/launch.sh .meta/mast/qwen3_1_7b_mast.yaml
```
https://www.internalfb.com/mlhub/pipelines/runs/mast/qwen3_1_7b_mast-k93wqk