### PR TITLE
Update model in `tests/sandbox/vllm/qwen2_5_32b.yaml`

### DIFF
--- a/tests/sandbox/vllm/qwen2_5_32b.yaml
+++ b/tests/sandbox/vllm/qwen2_5_32b.yaml
@@ -2,7 +2,7 @@
 
 policy:
   engine_args:
-    model: "Qwen/Qwen2.5-32B"
+    model: "Qwen/Qwen3-32B"
     tensor_parallel_size: 4
     pipeline_parallel_size: 1
     enforce_eager: true


### PR DESCRIPTION
The current model in the config is not in the HF cache, so using Qwen3 instead, which is in the cache.