### PR TITLE
[GRPO] Make dataloader deterministic

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -303,7 +303,7 @@ Question: What is 12 + 5?
         )
         self._base_dataset = self._base_dataset.map(gsm8k_transform)
         self._base_dataset = self._base_dataset.shuffle(seed=self.seed)
-        self._base_dataset.set_epoch(self._epoch)  # for determinism
+        self._base_dataset.set_epoch(self._epoch)
         self._iterator = iter(self._base_dataset)
 
     @endpoint


### PR DESCRIPTION
This will make the dataloader deliver the data in the same order each time.

# Test Plan
```
python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml
```
Added a breakpoint, and printed out the `prompt` in pdb:
<img width="808" height="131" alt="Screenshot 2025-12-01 at 4 39 26 PM" src="https://github.com/user-attachments/assets/2b5f71b0-cd8c-4579-a2d5-a8da3d2a79c6" />

Before, `prompt` was different across runs; after this PR `prompt` is the same across runs.