### PR TITLE
Add `entity: torchforge` to MAST configs

### DIFF
--- a/.meta/mast/qwen3_14b_mast.yaml
+++ b/.meta/mast/qwen3_14b_mast.yaml
@@ -17,6 +17,7 @@ rollout_threads: ${services.policy.num_replicas}   # Recommended to set equal to
 # Observability configuration
 metric_logging:
   wandb:
+    entity: torchforge
     project: "grpo-training"
     group: "grpo_exp_${oc.env:USER}"
     logging_mode: global_reduce

--- a/.meta/mast/qwen3_1_7b_mast.yaml
+++ b/.meta/mast/qwen3_1_7b_mast.yaml
@@ -17,6 +17,7 @@ rollout_threads: ${services.policy.num_replicas}   # Recommended to set equal to
 # Observability configuration
 metric_logging:
   wandb:
+    entity: torchforge
     project: "grpo-training"
     group: "grpo_exp_${oc.env:USER}"
     logging_mode: global_reduce

--- a/.meta/mast/qwen3_32b_mast.yaml
+++ b/.meta/mast/qwen3_32b_mast.yaml
@@ -17,6 +17,7 @@ rollout_threads: ${services.policy.num_replicas}   # Recommended to set equal to
 # Observability configuration
 metric_logging:
   wandb:
+    entity: torchforge
     project: "grpo-training"
     group: "grpo_exp_${oc.env:USER}"
     logging_mode: global_reduce

--- a/.meta/mast/qwen3_4b_mast.yaml
+++ b/.meta/mast/qwen3_4b_mast.yaml
@@ -17,6 +17,7 @@ rollout_threads: ${services.policy.num_replicas}   # Recommended to set equal to
 # Observability configuration
 metric_logging:
   wandb:
+    entity: torchforge
     project: "grpo-training"
     group: "grpo_exp_${oc.env:USER}"
     logging_mode: global_reduce

--- a/.meta/mast/qwen3_8b_mast.yaml
+++ b/.meta/mast/qwen3_8b_mast.yaml
@@ -17,6 +17,7 @@ rollout_threads: ${services.policy.num_replicas}   # Recommended to set equal to
 # Observability configuration
 metric_logging:
   wandb:
+    entity: torchforge
     project: "grpo-training"
     group: "grpo_exp_${oc.env:USER}"
     logging_mode: global_reduce


### PR DESCRIPTION
This will write the MAST wandb logs to the torchforge "entity" in Wandb.

https://docs.wandb.ai/models/ref/python/functions/init

> entity: The username or team name the runs are logged to.