### PR TITLE
Fix example command in `sandbox/rl_trainer/main.py`

### DIFF
--- a/tests/sandbox/rl_trainer/main.py
+++ b/tests/sandbox/rl_trainer/main.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Usage: python -m tests.sandbox.rl_trainer.main --config apps/grpo/qwen3_32b.yaml
+# Usage: python -m tests.sandbox.rl_trainer.main --config apps/grpo/qwen3_1_7b.yaml
 
 import asyncio
 


### PR DESCRIPTION
The current example config does not work because it runs on slurm. Fixing to a command that does work and runs locally.