### PR TITLE
Easy fix to MAST launcher

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -233,7 +233,7 @@ class MastLauncher(BaseLauncher):
         return allocator, alloc_constraints, self.create_server_handle()
 
     async def remote_setup(self, procs: ProcMesh) -> None:
-        setup = procs.spawn(f"setup-{uuid.uuid1()}", MastSetupActor)
+        setup = procs.spawn("mast_setup", MastSetupActor)
         await setup.mount.call(mount_dst="/mnt/wsfuse")
 
     async def launch_mast_job(self):


### PR DESCRIPTION
Summary:
Monarch automatically appends uuid as of D88277771
which causes breakage in the forge MAST launcher 

https://www.internalfb.com/msl/studio/runs/mast/qwen3_1_7b_mast-pnci9b/summary

```
thread 'monarch-pytokio-worker-212' (3047) panicked at fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs:686:35:
called `Result::unwrap()` on an `Err` value: ClonePyErr { inner: PyErr { type: <class 'RuntimeError'>, value: RuntimeError("invalid name 'setup-d0f5618a-d440-11f0-bb66-0b90684f2db0'"), traceback: None } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'monarch-pytokio-worker-212' (3047) panicked at fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs:691:38:
called `Result::unwrap()` on an `Err` value: RecvError(())
```

Differential Revision: D88647032


