### PR TITLE
Add warm storage related env variables to MAST setup

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -297,6 +297,8 @@ class MastLauncher(BaseLauncher):
                 "TORCHSTORE_RDMA_ENABLED": "1",
                 "HF_HOME": "/mnt/wsfuse/teamforge/hf",
                 "TRANSFORMERS_OFFLINE": "1",
+                "FUSE_SRC": "ws://ws.ai.pci0ai/genai_fair_llm",
+                "FUSE_DST": "/mnt/wsfuse",
             },
         }
 


### PR DESCRIPTION
With the latest forge conda fbpkg, we are seeing a breakage without setting these env variables - discovered by @JenniferWang. It is unclear what changed in the fbpkg to require this update...