### PR TITLE
Update the forge fbpkg to always use the one with tag `latest_conveyor_build` in MAST setup

### DIFF
--- a/.meta/mast/env_setup.sh
+++ b/.meta/mast/env_setup.sh
@@ -9,7 +9,7 @@
 # Set up conda environment and install forge with mounting
 
 # Configuration
-CONDA_ENV_NAME="forge:314c3548ae691f4aa2e49f1b1fad06b3"
+CONDA_ENV_NAME="forge:latest_conveyor_build"
 
 # Colors for output
 RED='\033[0;31m'


### PR DESCRIPTION
We should always be using the latest "stable" fbpkg, since others are ephemeral and expire.

# Test Plan
```
source .meta/mast/env_setup.sh
./.meta/mast/launch.sh .meta/mast/qwen3_1_7b_mast.yaml
```
https://www.internalfb.com/msl/studio/runs/mast/qwen3_1_7b_mast-5c2l2r