### PR TITLE
Remove `cif` from python path in `src/forge/controller/launcher.py`

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -277,8 +277,6 @@ class MastLauncher(BaseLauncher):
         ]
         additional_python_paths.append(self.remote_work_dir)
 
-        # needed for wandb api key extraction from secret
-        additional_python_paths.append("/packages/cif")
         default_envs = {
             **meta_hyperactor.DEFAULT_NVRT_ENVS,
             **meta_hyperactor.DEFAULT_NCCL_ENVS,


### PR DESCRIPTION
It is no longer needed to add `cif` to the python path manually after Kiuk's recent fix.

# Test Plan
```
source .meta/mast/env_setup.sh
./.meta/mast/launch.sh .meta/mast/qwen3_1_7b_mast.yaml
```
Confirmed wandb api key extraction still works.