### PR TITLE
Small fix to `qwen3_4b_mast.yaml`

### DIFF
--- a/.meta/mast/qwen3_4b_mast.yaml
+++ b/.meta/mast/qwen3_4b_mast.yaml
@@ -6,7 +6,7 @@ group_size: 8
 local_batch_size: 16 # per-device batch size
 max_req_tokens: 512
 max_res_tokens: 512
-model: "Qwen/Qwen3-4B"
+model: /mnt/wsfuse/teamforge/hf/qwen3_4b
 off_by_n: 1 # Off by one by default
 launcher: mast
 compile: true # Enable torch.compile for trainer/ref_model, and CUDA graphs for vLLM


### PR DESCRIPTION
## Description
Before this PR, the job is failing with: https://www.internalfb.com/msl/studio/runs/mast/qwen3_4b_mast-po4ma8
```
huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach https://huggingface.co/api/models/Qwen/Qwen3-4B: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable.
```

## Test plan
```
./.meta/mast/launch.sh .meta/mast/qwen3_4b_mast.yaml
```

After this PR, the job fails with a new error:
https://www.internalfb.com/msl/studio/runs/mast/qwen3_4b_mast-wsqui8