### PR TITLE
easy - [fix] update prompt

### DIFF
--- a/apps/grpo/data.py
+++ b/apps/grpo/data.py
@@ -30,10 +30,14 @@ class DatasetActor(ForgeActor):
         self._epoch = 0
 
         def gsm8k_transform(sample):
-            system_prompt = """
-            Put all your scratchpad work between <think> and </think> tags.
-            Your final answer should be between <answer> and </answer> tags otherwise it will not be scored.
-            """
+            system_prompt = (
+                "A conversation between User and Assistant. The user asks a question, "
+                "and the Assistant solves it. The assistant first thinks about the reasoning "
+                "process and then provides the user with the answer. The reasoning "
+                "process and answer are enclosed within <think></think> and <answer></answer> "
+                "tags, respectively, i.e., <think>reasoning process here</think> "
+                "<answer>answer here</answer>."
+            )
             request: str = sample["question"]
             as_chat = [
                 {"role": "system", "content": system_prompt},


### PR DESCRIPTION
## Description

In https://github.com/meta-pytorch/torchforge/issues/652, @shangshang-wang shared that outputs by qwen model looked weird with:
- repeated /think tags at the end;
- <tool_call> in the middle of the answer
- A lot of thinking outside of <think> tags

In the post, he also compared it with TorchTune, showing that Tune outputs behaved better.

I was able to reproduce the results in Forge with Qwen3 1.7b and proceeded to investigate. Some hypothesis:
1. [REJECTED] Training is wrong (e.g. masking) and is corrupting the output: This is rejected because i see this behavior in the very first step, before any gradient
2. [REJECTED] Different sampling params (e.g. top-p): Torchtune and Forge had the same params
3. [ACCEPTED] Different chat template: 
Indeed, there are 2 major differences here

- a) Torchtune doesn't use a chat template. They use raw text (perhaps because the tested model was qwen 2.5? I didn't confirm). You can see that Tune manually adds think tag, for example, instead of letting the template take care of it. Tune also doesnt have the |im_start| tag in the example given and it ends with |endoftext|, different from ours. Its a good practice to use the chat template, as per [HF documentation ](https://huggingface.co/Qwen/Qwen3-1.7B#advanced-usage-switching-between-thinking-and-non-thinking-modes-via-user-input). This should be an argument in favor of forge, so the error couldnt be it.

- b. Tune prompt is actually different from Forge.
<img width="942" height="343" alt="image" src="https://github.com/user-attachments/assets/143f111c-1d01-4781-8c95-110588ba5bf0" />

Not only the content is different, but also the formatting. Using the """prompt""" adds space before each line of the prompt and line breaks instead of a single paragraph.

Upon changing the prompt, I inspected the results, and they look more like what we would expect, e.g.

```
[...]
I don't see any errors in this reasoning. All the steps are logical and the variables cancel out correctly. So the answer is 5 months.
</think> <answer>Jolyn is 5 months older than Leon.</answer>
```

## Test plan
<img width="1562" height="609" alt="image" src="https://github.com/user-attachments/assets/f0730844-3cb4-43ce-9a6b-da075dc6f3ab" />
