### PR TITLE
remove hard-coded versions from assets/versions.sh and fix CUDA path in scripts/install.s

### DIFF
--- a/assets/versions.sh
+++ b/assets/versions.sh
@@ -10,8 +10,6 @@
 # Stable versions of upstream libraries for OSS repo
 PYTORCH_VERSION="2.9.0"
 VLLM_VERSION="v0.10.0"
-MONARCH_NIGHTLY_VERSION="2025.12.17"
-TORCHTITAN_VERSION="0.2.0"
 TORCHSTORE_BRANCH="no-monarch-2025.12.17"
 
 # Torchtitan commit hash for launching on MAST


### PR DESCRIPTION
Summary: There's no need to specify the package version for `torchmonarch-nightly` and `torchtitan` in two separate places. We leave the canonical version in `pyproject.yaml` and remove the ones from `assets/versions.sh`

Differential Revision: D89667000


