### PR TITLE
Move compile config from training to top-level

### DIFF
--- a/apps/sft/llama3_8b.yaml
+++ b/apps/sft/llama3_8b.yaml
@@ -26,12 +26,14 @@ optimizer:
 lr_scheduler:
   warmup_steps: 200
 
+compile:
+  enable: false
+
 training:
   local_batch_size: 8
   seq_len: 2048
   max_norm: 1.0
   steps: 1000
-  compile: false
   datasets:
     - path: "yahma/alpaca-cleaned"
       split: "train[:95%]"

--- a/apps/sft/main.py
+++ b/apps/sft/main.py
@@ -96,11 +96,11 @@ class ForgeSFTRecipe(ForgeActor, ForgeEngine):
     @endpoint
     async def setup(self):
         # Validate that compile is only used with flex attention
-        if self.job_config.training.compile:
+        if self.job_config.compile.enable:
             raise ValueError(
-                "training.compile=True is not currently supported. "
+                "compile.enable=True is not currently supported. "
                 "Compile is only supported with flex attention enabled, which requires PyTorch nightly. "
-                "Please set training.compile=false in your config."
+                "Please set compile.enable=false in your config."
             )
 
         # all ranks should record loss, except when PP=True. Then, only the last stage should record loss.

--- a/apps/sft/qwen3_8b.yaml
+++ b/apps/sft/qwen3_8b.yaml
@@ -25,12 +25,14 @@ optimizer:
 lr_scheduler:
   warmup_steps: 200
 
+compile:
+  enable: false
+
 training:
   local_batch_size: 8
   seq_len: 2048
   max_norm: 1.0
   steps: 1000
-  compile: false
   datasets:
     - path: "yahma/alpaca-cleaned"
       split: "train[:95%]"


### PR DESCRIPTION
- Move compile from training.compile to compile.enable in llama3_8b.yaml
- Move compile from training.compile to compile.enable in qwen3_8b.yaml
- Update main.py to use job_config.compile.enable instead of job_config.training.compile

This aligns the YAML config structure with ForgeJobConfig's expected schema, where compile is a separate top-level dataclass, not nested under training.

See: https://github.com/pytorch/torchtitan/blob/29aafb91b7fbffe2ee259919a3249a0eb1d70779/torchtitan/experiments/forge/job_config.py#L42 where compile is a class not under training.