### PR TITLE
[Generator] add generator offline throughput benchmark

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TorchForge benchmarking utilities."""

--- a/benchmarks/generator/__init__.py
+++ b/benchmarks/generator/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generator throughput benchmarking tools."""

--- a/benchmarks/generator/datasets.py
+++ b/benchmarks/generator/datasets.py
@@ -1,0 +1,144 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Lightweight dataset utilities for generator throughput benchmarking.
+"""
+
+import random
+import uuid
+from dataclasses import dataclass
+from vllm import __version__ as vllm_version
+
+
+if vllm_version >= "0.13.0":
+    from vllm.tokenizers import TokenizerLike as Tokenizer
+else:
+    from vllm.transformers_utils.tokenizer import AnyTokenizer as Tokenizer
+
+
+@dataclass
+class BenchmarkRequest:
+    """
+    Attributes:
+        prompt: The text prompt to generate from
+        prompt_len: Length of the prompt in tokens
+        expected_output_len: Expected length of generated output in tokens
+        request_id: Unique identifier for this request.
+    """
+
+    prompt: str
+    prompt_len: int
+    expected_output_len: int
+    request_id: str
+
+
+class RandomDataset:
+    """Generates prompts with random token sequences of specified lengths.
+
+    Args:
+        tokenizer: Tokenizer to use for encoding/decoding
+        num_requests: Number of benchmark requests to generate
+        input_len: Target input prompt length in tokens
+        output_len: Target output generation length in tokens
+        range_ratio: Variance ratio for input/output lengths (0.0-1.0).
+                     0.0 means fixed lengths, 0.2 means ±20% variance.
+    """
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        num_requests: int,
+        input_len: int,
+        output_len: int,
+        range_ratio: float = 0.0,
+    ):
+        self.tokenizer = tokenizer
+        self.num_requests = num_requests
+        self.input_len = input_len
+        self.output_len = output_len
+        self.range_ratio = range_ratio
+        self.vocab_size = tokenizer.vocab_size
+
+    def _sample_length(self, target_len: int) -> int:
+        """Sample a length with variance based on range_ratio."""
+        if self.range_ratio == 0.0:
+            return target_len
+
+        min_len = int(target_len * (1 - self.range_ratio))
+        max_len = int(target_len * (1 + self.range_ratio))
+        return random.randint(min_len, max_len)
+
+    def generate(self) -> list[BenchmarkRequest]:
+        """Generate benchmark requests with random token sequences.
+
+        Returns:
+            List of BenchmarkRequest objects with random prompts
+        """
+        requests = []
+
+        for i in range(self.num_requests):
+            # Sample lengths with variance
+            prompt_len = self._sample_length(self.input_len)
+            output_len = self._sample_length(self.output_len)
+
+            token_ids = [random.randint(0, self.vocab_size - 1) for _ in range(prompt_len)]
+            prompt = self.tokenizer.decode(token_ids)
+
+            requests.append(
+                BenchmarkRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                    request_id=f"random-{i}-{uuid.uuid4().hex[:8]}",
+                )
+            )
+
+        return requests
+
+
+class FixedDataset:
+    """Repeat a fixed prompt for baseline testing.
+
+    Args:
+        tokenizer: Tokenizer to use for encoding the prompt
+        prompt: The fixed text prompt to repeat
+        num_requests: Number of times to repeat the prompt
+        output_len: Target output generation length in tokens
+    """
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        prompt: str,
+        num_requests: int,
+        output_len: int,
+    ):
+        self.tokenizer = tokenizer
+        self.prompt = prompt
+        self.num_requests = num_requests
+        self.output_len = output_len
+        self.prompt_len = len(tokenizer.encode(prompt))
+
+    def generate(self) -> list[BenchmarkRequest]:
+        """Generate benchmark requests with the same fixed prompt.
+
+        Returns:
+            List of BenchmarkRequest objects with the fixed prompt
+        """
+        requests = []
+
+        for i in range(self.num_requests):
+            requests.append(
+                BenchmarkRequest(
+                    prompt=self.prompt,
+                    prompt_len=self.prompt_len,
+                    expected_output_len=self.output_len,
+                    request_id=f"fixed-{i}-{uuid.uuid4().hex[:8]}",
+                )
+            )
+
+        return requests

--- a/benchmarks/generator/metrics.py
+++ b/benchmarks/generator/metrics.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Metrics collection and reporting for generator throughput benchmarks.
+
+Based on vLLM's throughput benchmark metrics patterns.
+Reference: vllm/benchmarks/throughput.py (lines 762-809)
+"""
+
+import json
+from dataclasses import asdict, dataclass
+
+from forge.data_models.completion import Completion
+
+
+@dataclass
+class ThroughputMetrics:
+    """Throughput benchmark metrics for offline inference.
+    Reference: https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/throughput.py
+
+    Attributes:
+        elapsed_time: Total wall-clock time in seconds
+        num_requests: Total number of requests processed
+        num_completions: Total number of completions (requests * n samples)
+        total_prompt_tokens: Sum of all prompt tokens
+        total_output_tokens: Sum of all generated output tokens
+        total_tokens: Sum of prompt and output tokens
+        requests_per_second: Request throughput (requests/sec)
+        completions_per_second: Completion throughput (completions/sec)
+        tokens_per_second: Total token throughput (tokens/sec)
+        output_tokens_per_second: Output token throughput (output tokens/sec)
+        model: Optional model name for reporting
+        config: Optional benchmark configuration dict
+    """
+
+    elapsed_time: float
+    num_requests: int
+    num_completions: int
+    total_prompt_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    requests_per_second: float
+    completions_per_second: float
+    tokens_per_second: float
+    output_tokens_per_second: float
+    model: str | None = None
+    config: dict | None = None
+
+
+def extract_token_counts(completions: list[list[Completion]]) -> tuple[int, int]:
+    """Extract token counts from generator completions.
+
+    Args:
+        completions: List of completion lists from Generator.generate() calls.
+                     Each Generator.generate() call returns a list of Completion objects.
+
+    Returns:
+        Tuple of (total_prompt_tokens, total_output_tokens)
+    """
+    total_prompt_tokens = 0
+    total_output_tokens = 0
+
+    for completion_list in completions:
+        for completion in completion_list:
+            # Completion has prompt_ids and token_ids as torch.Tensor
+            # Shape: (seq_len,)
+            total_prompt_tokens += completion.prompt_ids.shape[0]
+            total_output_tokens += completion.token_ids.shape[0]
+
+    return total_prompt_tokens, total_output_tokens
+
+
+def calculate_metrics(
+    completions: list[list[Completion]],
+    elapsed_time: float,
+    model: str | None = None,
+    config: dict | None = None,
+) -> ThroughputMetrics:
+    """Calculate throughput metrics from completions and timing.
+
+    Args:
+        completions: List of completion lists from Generator.generate() calls
+        elapsed_time: Total time elapsed in seconds
+        model: Optional model name
+        config: Optional benchmark configuration
+
+    Returns:
+        ThroughputMetrics object with calculated metrics
+    """
+    num_requests = len(completions)
+    num_completions = sum(len(completion_list) for completion_list in completions)
+    total_prompt_tokens, total_output_tokens = extract_token_counts(completions)
+    total_tokens = total_prompt_tokens + total_output_tokens
+
+    return ThroughputMetrics(
+        elapsed_time=elapsed_time,
+        num_requests=num_requests,
+        num_completions=num_completions,
+        total_prompt_tokens=total_prompt_tokens,
+        total_output_tokens=total_output_tokens,
+        total_tokens=total_tokens,
+        requests_per_second=num_requests / elapsed_time if elapsed_time > 0 else 0.0,
+        completions_per_second=num_completions / elapsed_time if elapsed_time > 0 else 0.0,
+        tokens_per_second=total_tokens / elapsed_time if elapsed_time > 0 else 0.0,
+        output_tokens_per_second=(
+            total_output_tokens / elapsed_time if elapsed_time > 0 else 0.0
+        ),
+        model=model,
+        config=config,
+    )
+
+
+def print_metrics(metrics: ThroughputMetrics) -> None:
+    """Print metrics to console in a formatted table.
+
+    Args:
+        metrics: ThroughputMetrics to print
+    """
+    print("=" * 55)
+    print("Throughput Benchmark Results".center(55))
+    print("=" * 55)
+
+    if metrics.model:
+        print(f"Model: {metrics.model}")
+
+    # Calculate samples per request
+    samples_per_request = metrics.num_completions / metrics.num_requests if metrics.num_requests > 0 else 0
+
+    print(f"Requests: {metrics.num_requests}")
+    print(f"Completions: {metrics.num_completions} ({samples_per_request:.1f} per request)")
+    print(f"Elapsed Time: {metrics.elapsed_time:.2f} seconds")
+    print("-" * 55)
+    print(f"Total Prompt Tokens: {metrics.total_prompt_tokens}")
+    print(f"Total Output Tokens: {metrics.total_output_tokens}")
+    print(f"Total Tokens: {metrics.total_tokens}")
+    print("-" * 55)
+    print("Throughput:")
+    print(f"  Requests/sec: {metrics.requests_per_second:.2f}")
+    print(f"  Completions/sec: {metrics.completions_per_second:.2f}")
+    print(f"  Total Tokens/sec: {metrics.tokens_per_second:.2f}")
+    print(f"  Output Tokens/sec: {metrics.output_tokens_per_second:.2f}")
+    print("=" * 55)
+
+
+def save_metrics_json(metrics: ThroughputMetrics, output_path: str) -> None:
+    """Save metrics to JSON file.
+
+    Args:
+        metrics: ThroughputMetrics to save
+        output_path: Path to output JSON file
+    """
+    metrics_dict = asdict(metrics)
+
+    with open(output_path, "w") as f:
+        json.dump(metrics_dict, f, indent=2)
+
+    print(f"\nMetrics saved to: {output_path}")

--- a/benchmarks/generator/throughput.py
+++ b/benchmarks/generator/throughput.py
@@ -1,0 +1,296 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Offline throughput benchmark for torchforge generators.
+
+Based on vLLM's offline throughput pattern but adapted for torchforge's
+generator infrastructure. Measures maximum generation throughput without
+simulating request arrival patterns.
+
+Reference: https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/throughput.py
+
+Example usage:
+    # Using config file with defaults (randomly generated prompt)
+    python -m benchmarks.generator.throughput --config apps/grpo/qwen3_1_7b.yaml
+
+    # With benchmark parameter overrides
+    python -m benchmarks.generator.throughput \\
+        --config apps/grpo/qwen3_1_7b.yaml \\
+        benchmark.num_requests=100 \\
+        benchmark.input_len=1024 \\
+        benchmark.output_len=2048 \\
+        benchmark.dataset=random \\
+        benchmark.output_json=results.json
+
+    # For sanity check, you could use a fixed prompt and sample the responses.
+    python -m benchmarks.generator.throughput \\
+        --config apps/grpo/qwen3_1_7b.yaml \\
+        benchmark.num_requests=10 \\
+        benchmark.dataset=fixed \\
+        benchmark.fixed_prompt="Tell me a joke" \\
+        benchmark.num_samples=5
+"""
+
+import argparse
+import asyncio
+import os
+import random
+import time
+
+from benchmarks.generator.datasets import BenchmarkRequest, FixedDataset, RandomDataset
+from benchmarks.generator.metrics import calculate_metrics, print_metrics, save_metrics_json
+from forge.actors.generator import Generator
+from forge.controller.provisioner import init_provisioner, shutdown
+from forge.types import LauncherConfig, ProvisionerConfig
+from forge.util.config import parse
+from omegaconf import DictConfig, OmegaConf
+
+from vllm import __version__ as vllm_version
+
+if vllm_version >= "0.13.0":
+    from vllm.tokenizers import get_tokenizer
+else:
+    from vllm.transformers_utils.tokenizer import get_tokenizer
+
+os.environ.setdefault("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT_SECS", "600")
+os.environ.setdefault("HYPERACTOR_CODE_MAX_FRAME_LENGTH", "1073741824")
+
+
+async def run_throughput_benchmark(
+    cfg: DictConfig,
+    num_requests: int,
+    input_len: int,
+    output_len: int,
+    dataset_type: str = "random",
+    range_ratio: float = 0.0,
+    fixed_prompt: str | None = None,
+    output_json: str | None = None,
+    num_samples: int = 5,
+) -> None:
+    """Run offline throughput benchmark.
+
+    Based on vLLM's run_vllm() pattern (throughput.py:42-122).
+
+    Args:
+        cfg: TorchForge config from YAML
+        num_requests: Number of requests to benchmark
+        input_len: Input prompt length in tokens
+        output_len: Output generation length in tokens
+        dataset_type: Dataset type ("random" or "fixed")
+        range_ratio: Variance ratio for input/output lengths (0.0-1.0)
+        fixed_prompt: Prompt to use for "fixed" dataset type
+        output_json: Optional path to save JSON metrics
+        num_samples: Number of sample responses to print (0 to print all)
+    """
+    if cfg.get("provisioner", None) is not None:
+        await init_provisioner(
+            ProvisionerConfig(launcher_config=LauncherConfig(**cfg.provisioner))
+        )
+
+    print("Spawning Generator service...")
+    generator = await Generator.options(**cfg.services.policy).as_service(**cfg.policy)
+
+    print(f"Generating {num_requests} benchmark requests...")
+    model_name = cfg.policy.engine_args.get("model", "unknown")
+    tokenizer = get_tokenizer(
+        model_name,
+        tokenizer_mode="auto",
+        trust_remote_code=True,
+    )
+
+    if dataset_type == "random":
+        dataset = RandomDataset(
+            tokenizer=tokenizer,
+            num_requests=num_requests,
+            input_len=input_len,
+            output_len=output_len,
+            range_ratio=range_ratio,
+        )
+    elif dataset_type == "fixed":
+        if fixed_prompt is None:
+            fixed_prompt = "Tell me a joke"
+        dataset = FixedDataset(
+            tokenizer=tokenizer,
+            prompt=fixed_prompt,
+            num_requests=num_requests,
+            output_len=output_len,
+        )
+    else:
+        raise ValueError(f"Unknown dataset type: {dataset_type}")
+
+    requests: list[BenchmarkRequest] = dataset.generate()
+
+    print(f"\nRunning throughput benchmark ({num_requests} requests)...")
+    prompts = [req.prompt for req in requests]
+    request_ids = [req.request_id for req in requests]
+
+    start = time.perf_counter()
+    # TODO: here we're measuring two things together: vllm generation and data transmition.
+    # We shall consider finer grained metrics collection to distinguish the two steps.
+    completions = await asyncio.gather(*[generator.generate.route(prompt) for prompt in prompts])
+    end = time.perf_counter()
+
+    elapsed_time = end - start
+
+    print("\nBenchmark completed!")
+
+    config_dict = {
+        "num_requests": num_requests,
+        "input_len": input_len,
+        "output_len": output_len,
+        "dataset_type": dataset_type,
+        "range_ratio": range_ratio,
+    }
+
+    metrics = calculate_metrics(
+        completions=completions,
+        elapsed_time=elapsed_time,
+        model=model_name,
+        config=config_dict,
+    )
+
+    print_metrics(metrics)
+
+    if output_json:
+        save_metrics_json(metrics, output_json)
+
+    if dataset_type == "fixed" and completions:
+        print("\n" + "=" * 80)
+        print("SAMPLED RESPONSES (Fixed Prompt)")
+        print("=" * 80)
+        print(f"\nPrompt: {fixed_prompt or 'Tell me a joke'}")
+
+        # Flatten completions: each request returns multiple completions (n samples)
+        # completions is list[list[Completion]] where outer list = requests, inner list = n samples
+        all_completions = []
+        all_request_ids = []
+        for req_idx, completion_group in enumerate(completions):
+            for sample_idx, completion in enumerate(completion_group):
+                all_completions.append(completion)
+                all_request_ids.append(f"{request_ids[req_idx]}-sample{sample_idx}")
+
+        samples_to_show = len(all_completions) if num_samples == 0 else min(num_samples, len(all_completions))
+        print(f"\nShowing {samples_to_show} of {len(all_completions)} total completions")
+        print(f"({len(completions)} requests × {len(completions[0])} samples per request)\n")
+
+        # Randomly sample from all completions
+        if samples_to_show < len(all_completions):
+            sample_indices = random.sample(range(len(all_completions)), samples_to_show)
+            sample_indices.sort()
+        else:
+            sample_indices = range(len(all_completions))
+
+        for i, idx in enumerate(sample_indices, 1):
+            completion = all_completions[idx]
+            request_id = all_request_ids[idx]
+            print(f"\n--- Response {i} (Request ID: {request_id}) ---")
+            print(completion.text)
+            print("-" * 40)
+
+        print("\n" + "=" * 80)
+
+    print("\nShutting down...")
+    await shutdown()
+
+
+def add_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add CLI arguments for throughput benchmark.
+
+    Based on vLLM's add_cli_args() pattern (throughput.py:544-696).
+    """
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to torchforge YAML config file",
+    )
+    parser.add_argument(
+        "--num-requests",
+        type=int,
+        default=100,
+        help="Number of requests to benchmark (default: 100)",
+    )
+    parser.add_argument(
+        "--input-len",
+        type=int,
+        default=128,
+        help="Input prompt length in tokens (default: 128)",
+    )
+    parser.add_argument(
+        "--output-len",
+        type=int,
+        default=128,
+        help="Output generation length in tokens (default: 128)",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        choices=["random", "fixed"],
+        default="random",
+        help="Dataset type: random or fixed (default: random)",
+    )
+    parser.add_argument(
+        "--range-ratio",
+        type=float,
+        default=0.0,
+        help="Variance ratio for input/output lengths (default: 0.0 for fixed lengths)",
+    )
+    parser.add_argument(
+        "--fixed-prompt",
+        type=str,
+        default=None,
+        help="Prompt to use for 'fixed' dataset type (default: 'Tell me a joke')",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Path to save JSON metrics (optional)",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=5,
+        help="Number of sample responses to print for fixed prompts (0 to print all, default: 5)",
+    )
+
+
+@parse
+def recipe_main(cfg: DictConfig) -> None:
+    """Main entry point for throughput benchmark.
+
+    Args:
+        cfg: Config loaded from YAML file via @parse decorator.
+             Benchmark parameters can be specified in the config or via key=value overrides like
+             python -m benchmarks.generator.throughput --config apps/grpo/qwen3_1_7b.yaml benchmark.num_requests=200
+    """
+    benchmark_cfg = cfg.get("benchmark", {})
+    num_requests = benchmark_cfg.get("num_requests", 100)
+    input_len = benchmark_cfg.get("input_len", 1024)
+    output_len = benchmark_cfg.get("output_len", 2048)
+    dataset_type = benchmark_cfg.get("dataset", "random")
+    range_ratio = benchmark_cfg.get("range_ratio", 0.0)
+    fixed_prompt = benchmark_cfg.get("fixed_prompt", None)
+    output_json = benchmark_cfg.get("output_json", None)
+    num_samples = benchmark_cfg.get("num_samples", 5)
+
+    asyncio.run(
+        run_throughput_benchmark(
+            cfg=cfg,
+            num_requests=num_requests,
+            input_len=input_len,
+            output_len=output_len,
+            dataset_type=dataset_type,
+            range_ratio=range_ratio,
+            fixed_prompt=fixed_prompt,
+            output_json=output_json,
+            num_samples=num_samples,
+        )
+    )
+
+
+if __name__ == "__main__":
+    recipe_main()


### PR DESCRIPTION
# Summary:
Add offline throughput benchmark for the generator for iterating on vLLM refactoring.
The benchmark can indeed serve two purposes
1. `random` dataset for testing throughput
2. `fixed` dataset with fixed prompt for sanity check the response

Differential Revision: D89768647

# Test Plan: 
Rebase on top of D89667182 v0.13.0  to test v0.13.0 compatibility
```
python -m benchmarks.generator.throughput         --config apps/grpo/qwen3_1_7b.yaml         benchmark.num_requests=100         benchmark.input_len=1024         benchmark.output_len=2048         benchmark.dataset=random         benchmark.output_json=v0.10.results.json
```
```
{
  "elapsed_time": 209.82506129099056,
  "num_requests": 100,
  "num_completions": 800,
  "total_prompt_tokens": 864088,
  "total_output_tokens": 1379964,
  "total_tokens": 2244052,
  "requests_per_second": 0.4765874933372117,
  "completions_per_second": 3.8126999466976934,
  "tokens_per_second": 10694.871175983566,
  "output_tokens_per_second": 6576.73583655592,
  "model": "Qwen/Qwen3-1.7B",
  "config": {
    "num_requests": 100,
    "input_len": 1024,
    "output_len": 2048,
    "dataset_type": "random",
    "range_ratio": 0.0
  }
}
```

Rebase on top of main to test v0.10.0 compatibility
```
{
  "elapsed_time": 222.37684379698476,
  "num_requests": 100,
  "num_completions": 800,
  "total_prompt_tokens": 861648,
  "total_output_tokens": 1410319,
  "total_tokens": 2271967,
  "requests_per_second": 0.4496871090197383,
  "completions_per_second": 3.5974968721579064,
  "tokens_per_second": 10216.742720182478,
  "output_tokens_per_second": 6342.022739056083,
  "model": "Qwen/Qwen3-1.7B",
  "config": {
    "num_requests": 100,
    "input_len": 1024,
    "output_len": 2048,
    "dataset_type": "random",
    "range_ratio": 0.0
  }
}
```

Tested the fixed prompt: 
```
Benchmark completed!
=======================================================
              Throughput Benchmark Results             
=======================================================
Model: Qwen/Qwen3-1.7B
Requests: 10
Completions: 80 (8.0 per request)
Elapsed Time: 20.99 seconds
-------------------------------------------------------
Total Prompt Tokens: 320
Total Output Tokens: 163840
Total Tokens: 164160
-------------------------------------------------------
Throughput:
  Requests/sec: 0.48
  Completions/sec: 3.81
  Total Tokens/sec: 7820.24
  Output Tokens/sec: 7805.00
=======================================================
================================================================================
SAMPLED RESPONSES (Fixed Prompt)
================================================================================
Prompt: Tell me a joke
Showing 5 of 80 total completions
(10 requests × 8 samples per request)
--- Response 1 (Request ID: fixed-0-49163cd6-sample4) ---
 about cats and the internet.
Okay, so I need to come up with a joke that involves cats and the internet. Let's see... Cats are often associated with the internet in some way. Maybe they're using the internet, or they're doing something online. 
First, I should think about common cat behaviors. Cats use their paws to click, right? Like, they have a way of doing a "cat click" when they get a treat. That's a term used in pet behaviors. Maybe that can be a play on words.
Then, the internet. Maybe something like "cat videos" on social media. Or "cat" as in the online community. Or "cat and mouse" as in the internet being a place of distractions or something. 
Wait, here's an idea: cat videos on the internet. So, a joke that plays on the idea of a cat video and the internet. Maybe something like, "Why did the cat go online? Because it wanted to find a new mouse!" But that's a bit cliché. Maybe a better twist.
Another angle: internet slang. Like "cat" being a term in the internet, but that's not the case. Or "cat posts" as in something that's a joke or an online content.
Wait, maybe something like "The cat gave up the internet because it couldn't find a mouse." But that's not very funny. Maybe the classic "Why did the cat get a computer?" Because it wanted to play with the mouse. But the internet part isn't directly there. 
Alternatively, "My cat is a great internet user because he can do a Google search and a cat video search." Not sure.
Wait, here's a thought: the internet is full of cat videos. So, a joke that's funny about how cats are everywhere on the internet. Like, "What do you call a cat that's online? A cat with a net." But that's not quite right.
Another angle: The internet and the cat's behavior. Like, "Why was the cat sad when it went online? Because it couldn't find a catnip." But that's not really a joke. Maybe "Why did the cat go to the internet? To get more catnip."
Hmm. Maybe a pun on "cat" and "internet." Like, "What do you call a cat that's on the internet? A cat in the net." But that's a bit of a stretch. 
Alternatively, "The cat is on the internet, but it's not sure if it's on the right one." No, not funny.
Wait, here's a possible: "Cat and mouse." The internet is a place where there's so much cat and mouse interaction. But how to turn that into a joke. 
Maybe: "Why did the cat go to the internet? To get more mouse." But not sure. 
Another approach: The cat's behavior online. Like, the cat's online presence, the cat's social media. Maybe "Why did the cat get a social media account? Because it wanted to show off its online presence."
Wait, that's a bit too straightforward. Maybe a joke where the cat is doing something funny online, like "The cat tried to log on to the internet, but it kept getting a 'cat' error message. The user said, 'Ah, that's the cat mascot for the website.'" 
Hmm, that could work. Or maybe: "The cat was trying to connect to the internet, but it got a 'Connection Error: The cat is offline. Please re-connect the cat.'" Not sure. 

...
```


