### PR TITLE
Remove DCP weight update option from torchforge

### DIFF
--- a/src/forge/actors/_torchstore_utils.py
+++ b/src/forge/actors/_torchstore_utils.py
@@ -4,56 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import logging
-import shutil
-from dataclasses import dataclass
-
-import torch
-import torch.distributed.checkpoint as dcp
-from torch.distributed.checkpoint.metadata import Metadata as DcpMeta
-from torchstore.transport.buffers import rdma_available
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 KEY_DELIM = "."
-DCP_WHOLE_STATE_TAG = "dcp_whole_state_dict"
-
-
-@dataclass
-class DcpHandle:
-    checkpoint_id: str | None = None
-    metadata: DcpMeta | None = None
-    param_names: list[str] | None = None
-
-    def drop(self) -> None:
-        if self.checkpoint_id is None:
-            raise ValueError("Dropping a null DcpHandle")
-        if self.checkpoint_id.startswith("manifold://"):
-            # Probably don't need to delete the checkpoint if it's on manifold
-            logger.warning(
-                f"Skipping deletion of {self.checkpoint_id} since it's on manifold"
-            )
-            self.checkpoint_id = None
-            self.metadata = None
-            self.param_names = None
-            return
-
-        try:
-            shutil.rmtree(self.checkpoint_id, ignore_errors=False)
-            logger.debug(f"Removed old weights at {self.checkpoint_id}")
-        except OSError as e:
-            logger.error(f"Error deleting {self.checkpoint_id}: {e}")
-        finally:
-            self.checkpoint_id = None
-            self.metadata = None
-            self.param_names = None
-
-
-def load_tensor_from_dcp(handle: DcpHandle, param_name) -> torch.Tensor:
-    tensor_meta = handle.metadata.state_dict_metadata[param_name]
-    buffer = torch.empty(tensor_meta.size, dtype=tensor_meta.properties.dtype)
-    dcp.load(checkpoint_id=handle.checkpoint_id, state_dict={param_name: buffer})
-    return buffer
 
 
 def get_param_prefix(policy_version: int) -> str:
@@ -66,12 +21,3 @@ def get_param_key(policy_version: int, name: str) -> str:
 
 def extract_param_name(key: str) -> str:
     return KEY_DELIM.join(key.split(KEY_DELIM)[1:])
-
-
-def get_dcp_whole_state_dict_key(policy_version: int) -> str:
-    return f"{get_param_prefix(policy_version)}{KEY_DELIM}{DCP_WHOLE_STATE_TAG}"
-
-
-def rdma_enabled() -> bool:
-    """Return if TorchStore thinks we're using RDMA"""
-    return rdma_available()

--- a/src/forge/util/checkpoint.py
+++ b/src/forge/util/checkpoint.py
@@ -8,10 +8,7 @@ import time
 
 import torchstore as ts
 
-from forge.actors._torchstore_utils import (
-    get_dcp_whole_state_dict_key,
-    get_param_prefix,
-)
+from forge.actors._torchstore_utils import get_param_prefix
 
 
 async def drop_weights(version: int):
@@ -21,10 +18,6 @@ async def drop_weights(version: int):
     matching_keys = await ts.keys(prefix)
     # TODO: once we have something like `get_meta()` in torchstore, we can just
     # query the type of the object instead of relying on keys.
-    dcp_key = get_dcp_whole_state_dict_key(version)
-    if dcp_key in matching_keys:
-        dcp_handle = await ts.get(dcp_key)
-        dcp_handle.drop()
     for key in matching_keys:
         await ts.delete(key)
     elapsed = time.perf_counter() - start_time

--- a/tests/unit_tests/test_torchstore_utils.py
+++ b/tests/unit_tests/test_torchstore_utils.py
@@ -4,58 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import tempfile
+
 import unittest
 
-from pathlib import Path
-
-import pytest
-
-import torch
-import torch.distributed.checkpoint as dcp
-from forge.actors._torchstore_utils import DcpHandle
-
-ignore_torch_distributed_unitialized_warning = pytest.mark.filterwarnings(
-    r"ignore:.*torch.distributed"
+from forge.actors._torchstore_utils import (
+    extract_param_name,
+    get_param_key,
+    get_param_prefix,
 )
 
 
-class TestDcpHandle(unittest.TestCase):
-    def _prepare_dcp_handle(self, test_dir: str) -> tuple[str, DcpHandle]:
-        """Returns path to checkpoint and DcpHandle."""
-        checkpoint_id = str(Path(test_dir) / "test_checkpoint_id")
-        state_dict = {"a": torch.rand(1, 1), "b": torch.rand(1, 1)}
-        metadata = dcp.save(checkpoint_id=checkpoint_id, state_dict=state_dict)
-        assert os.path.exists(checkpoint_id), "failed to set up test checkpoint"
-        return checkpoint_id, DcpHandle(
-            checkpoint_id=checkpoint_id,
-            metadata=metadata,
-            param_names=list(state_dict.keys()),
-        )
+class TestTorchStoreUtils(unittest.TestCase):
+    def test_get_param_prefix(self) -> None:
+        self.assertEqual(get_param_prefix(1), "policy_ver_0000000001")
 
-    @ignore_torch_distributed_unitialized_warning
-    def test_dcp_handle_drop_deletes(self):
-        with tempfile.TemporaryDirectory() as test_dir:
-            ckpt_path, handle = self._prepare_dcp_handle(test_dir)
-            handle.drop()
-            self.assertFalse(os.path.exists(ckpt_path))
+    def test_get_param_key(self) -> None:
+        self.assertEqual(get_param_key(1, "test"), "policy_ver_0000000001.test")
 
-    @ignore_torch_distributed_unitialized_warning
-    def test_dcp_handle_drop_sets_none(self):
-        with tempfile.TemporaryDirectory() as test_dir:
-            _, handle = self._prepare_dcp_handle(test_dir)
-            handle.drop()
-            self.assertEqual(handle.checkpoint_id, None)
-            self.assertEqual(handle.metadata, None)
-            self.assertEqual(handle.param_names, None)
-
-    @ignore_torch_distributed_unitialized_warning
-    def test_dcp_handle_drop_sets_none_for_manifold(self):
-        with tempfile.TemporaryDirectory() as test_dir:
-            _, handle = self._prepare_dcp_handle(test_dir)
-            handle.checkpoint_id = "manifold://test_bucket/tree/test_path"
-            handle.drop()
-            self.assertEqual(handle.checkpoint_id, None)
-            self.assertEqual(handle.metadata, None)
-            self.assertEqual(handle.param_names, None)
+    def test_extract_param_name(self) -> None:
+        self.assertEqual(extract_param_name("policy_ver_0000000001.test"), "test")


### PR DESCRIPTION
Summary: Following profiling, we find that torchstore with Monarch RPC is faster or on par with using DCP for weight update / push, so in this PR we remove the DCP option and simplify the code.

Differential Revision: D89777952


