### PR TITLE
Upgrade torchtitan version in versions.sh to v0.2.1

### DIFF
--- a/assets/versions.sh
+++ b/assets/versions.sh
@@ -12,5 +12,5 @@ PYTORCH_VERSION="2.9.0"
 VLLM_VERSION="v0.10.0"
 TORCHSTORE_BRANCH="no-monarch-2025.12.17"
 
-# Torchtitan commit hash for launching on MAST
-TORCHTITAN_COMMIT_MAST="d0e25450bcac2332359b13fbda430dc701f073d4"
+# Torchtitan commit hash for launching on MAST, corresponds to v0.2.1
+TORCHTITAN_COMMIT_MAST="81af8833ddeff9b5f1874dc7e20594aa17da6b86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     # PyTorch
     "torch==2.9.0",
     "torchdata>=0.8.0",
-    "torchtitan==0.2.0",
+    "torchtitan==0.2.1",
     "torchmonarch-nightly==2025.12.17",
     # Issue 656: switch to ping torchstore nightly
     "torchstore",


### PR DESCRIPTION
Summary: A new stable version of torchtitan was just released (v0.2.1) corresponding to the commit here. The new version includes a [fix](https://github.com/pytorch/torchtitan/commit/fb549717a78362ad29ebc5e89bc0b4950cdfc04c) to a bug which will fix our weight sync test for Qwen 30B MoE (https://github.com/meta-pytorch/torchforge/pull/682)

Differential Revision: D89833771
