### PR TITLE
remove titan commit hash for MAST

### DIFF
--- a/assets/versions.sh
+++ b/assets/versions.sh
@@ -11,6 +11,3 @@
 PYTORCH_VERSION="2.9.0"
 VLLM_VERSION="v0.10.0"
 TORCHSTORE_BRANCH="no-monarch-2025.12.17"
-
-# Torchtitan commit hash for launching on MAST
-TORCHTITAN_COMMIT_MAST="d0e25450bcac2332359b13fbda430dc701f073d4"


### PR DESCRIPTION
Summary:
See the previous diff for context. Split the logic into two diffs to make GH
export work.

Reviewed By: daniellepintz

Differential Revision: D89903684


