### PR TITLE
Add integration test workflow to CI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,46 @@
+name: Integration Tests (8 card)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: integration-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+  integration_test:
+    if: github.repository_owner == 'meta-pytorch'
+    runs-on: linux.g4dn.metal.nvidia.gpu
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: '3.12'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Install vLLM requirements
+        run: |
+          pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128
+          pip install -r .github/packaging/vllm_reqs_12_8.txt
+          pip install six
+          pip install "setuptools<80"
+          python -m pip install vllm --no-cache-dir --index-url https://download.pytorch.org/whl/preview/forge
+      - name: Install torchforge
+        run: pip install uv && uv pip install . && uv pip install .[dev]
+      - name: Run weight sync integration test
+        run: pytest -s tests/integration_tests/test_policy_update.py::TestWeightSync::test_sanity_check --config tests/integration_tests/fixtures/qwen3_1_7b_tp.yaml


### PR DESCRIPTION
## Summary:
Adding a GH action workflow to test integration tests continuously. For now just testing `test_policy_update.py`. Will add other integration tests in next PRs.

Runs on every push to main, and on workflow_dispatch (manual trigger).

Also, needed to modify config of `qwen3_1_7b_tp.yaml` to use fewer GPUs because the CI machines only have 4 GPUs.

## Test Plan:
Test by adding `on: pull_request:` to the yaml file; then remove it before landing.

Job succeeds: https://github.com/meta-pytorch/torchforge/actions/runs/20723487277/job/59493218607?pr=693

Differential Revision: D90031998
