### PR TITLE
Fix `test_titan_fwd_vs_hf_fwd.py`

### DIFF
--- a/tests/integration_tests/test_titan_fwd_vs_hf_fwd.py
+++ b/tests/integration_tests/test_titan_fwd_vs_hf_fwd.py
@@ -146,7 +146,7 @@ async def generate_logits(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Generate logits from both models."""
     print("Generating logits from torchtitan model...")
-    titan_logits = await titan_model.forward.route(input_ids)
+    titan_logits = await titan_model.forward.route(input_ids, 64, False)
 
     print("Generating logits from HF model...")
     hf_logits = await hf_model.forward.route(input_ids)


### PR DESCRIPTION
## Summary
The `ReferenceModel.forward` API changed and this test was not updated:

https://github.com/meta-pytorch/torchforge/blob/b4b0e6ac6cfc8f2e9e38ae2d590c37342771d718/src/forge/actors/reference_model.py#L133-L135

## Test Plan
```
python tests/integration_tests/test_titan_fwd_vs_hf_fwd.py --model_name "Qwen/Qwen3-1.7B" --titan-model-family "qwen3" --titan-model-flavor "1.7B"
```
Fails before with `TypeError: missing a required argument: 'max_req_tokens'`

Succeeds after this PR

Differential Revision: D90114574


