### PR TITLE
Introduce integration test for generator lifecycle

### DIFF
--- a/tests/integration_tests/test_generator_lifecycle.py
+++ b/tests/integration_tests/test_generator_lifecycle.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Integration tests for Generator lifecycle management and resource cleanup.
+
+These tests verify:
+1. Resource cleanup during shutdown
+2. Proper termination of worker processes
+3. No dangling GPU processes after shutdown
+"""
+
+import os
+import time
+
+import psutil
+import pytest
+from forge.actors.generator import Generator
+
+
+# Force HuggingFace offline mode to avoid proxy issues
+os.environ["HF_HUB_OFFLINE"] = "1"
+
+# Use Qwen3-1.7B which is already cached and used in other tests
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+MAX_MODEL_LEN = 512
+GPU_MEMORY_UTILIZATION = 0.9
+# This disables CUDA graph optimizations and runs in eager mode, which is slower
+# but simpler for debugging/testing.
+ENFORCE_EAGER = True
+
+
+def get_child_processes(parent_pid=None):
+    """Get all child processes of the current process or a specific parent.
+
+    Args:
+        parent_pid: Parent process ID. If None, uses current process.
+
+    Returns:
+        List of psutil.Process objects for all children.
+    """
+    if parent_pid is None:
+        parent_pid = os.getpid()
+
+    try:
+        parent = psutil.Process(parent_pid)
+        children = parent.children(recursive=True)
+        return children
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return []
+
+
+def get_process_info(processes):
+    """Get detailed info about processes for debugging.
+
+    Args:
+        processes: List of psutil.Process objects.
+
+    Returns:
+        List of dicts with process info.
+    """
+    info = []
+    for proc in processes:
+        try:
+            info.append(
+                {
+                    "pid": proc.pid,
+                    "ppid": proc.ppid(),  # Parent process ID
+                    "name": proc.name(),
+                    "cmdline": " ".join(proc.cmdline()[:3]),  # First 3 args
+                    "status": proc.status(),
+                }
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return info
+
+
+def get_gpu_processes():
+    """Get processes using GPUs via nvidia-smi.
+
+    Returns:
+        Set of PIDs using GPUs.
+    """
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            pids = set()
+            for line in result.stdout.strip().split("\n"):
+                if line.strip():
+                    try:
+                        pids.add(int(line.strip()))
+                    except ValueError:
+                        continue
+            return pids
+        return set()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return set()
+
+
+@pytest.mark.asyncio
+async def test_generator_shutdown_cleanup():
+    """Test proper resource cleanup during shutdown for 2-GPU case.
+
+    Verifies:
+    - AsyncLLM shutdown is called
+    - Worker processes are stopped
+    - Generator process is stopped
+    - No dangling GPU processes after shutdown
+    - All child processes are properly cleaned up
+    """
+    generator = None
+
+    # Get baseline process count
+    initial_children = get_child_processes()
+    initial_child_count = len(initial_children)
+    initial_gpu_pids = get_gpu_processes()
+
+    print(f"[Baseline] Test process PID: {os.getpid()}")
+    print(f"[Baseline] Child processes: {initial_child_count}")
+    print(f"[Baseline] GPU processes: {len(initial_gpu_pids)}")
+
+    try:
+        generator = await Generator.options(
+            procs=2, num_replicas=1, with_gpus=True
+        ).as_service(
+            engine_args={
+                "model": MODEL_NAME,
+                "tensor_parallel_size": 2,
+                "enforce_eager": ENFORCE_EAGER,
+                "max_model_len": MAX_MODEL_LEN,
+                "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
+            },
+            sampling_params={
+                "max_tokens": 10,
+                "temperature": 0.0,
+            },
+        )
+
+        after_launch_children = get_child_processes()
+        after_launch_gpu_pids = get_gpu_processes()
+
+        print(f"[After Launch] Child processes: {len(after_launch_children)}")
+        print(f"[After Launch] GPU processes: {len(after_launch_gpu_pids)}")
+
+        # Should have more processes after launch
+        assert (
+            len(after_launch_children) > initial_child_count
+        ), "Expected child processes to be created during launch"
+        assert len(after_launch_gpu_pids) > len(
+            initial_gpu_pids
+        ), "Expected GPU processes to be created during launch"
+
+        await generator.shutdown()
+
+        # Wait a bit for cleanup
+        time.sleep(2)
+
+        final_children = get_child_processes()
+        final_gpu_pids = get_gpu_processes()
+
+        print(f"[After Shutdown] Child processes: {len(final_children)}")
+        print(f"[After Shutdown] GPU processes: {len(final_gpu_pids)}")
+
+        # Check for dangling child processes
+        if len(final_children) > initial_child_count:
+            dangling = get_process_info(final_children)
+
+            print("\n⚠️  Dangling child processes detected:")
+            for proc_info in dangling:
+                print(
+                    f"  - PID {proc_info['pid']} (PPID {proc_info['ppid']}): {proc_info['name']} ({proc_info['status']})"
+                )
+                print(f"    CMD: {proc_info['cmdline']}")
+
+            print(
+                f"\nTotal: {len(dangling)} dangling processes after shutdown (baseline: {initial_child_count})."
+                "This seems to be benigh as they'll be cleaned up when the parent process exits. "
+                "See P2106216182 for repro with just monarch primitives."
+            )
+        else:
+            print("\n✅ No dangling child processes detected")
+
+        # Check for dangling GPU processes
+        new_gpu_pids = final_gpu_pids - initial_gpu_pids
+        if new_gpu_pids:
+            print(f"⚠️  Dangling GPU processes detected: {new_gpu_pids}")
+            raise AssertionError(
+                f"Found {len(new_gpu_pids)} dangling GPU processes after shutdown"
+            )
+
+        print("✅ No dangling GPU processes detected")
+
+    finally:
+        if generator is not None:
+            try:
+                await generator.shutdown()
+            except Exception:
+                pass  # Already shut down


### PR DESCRIPTION
Summary:
## Context 
Add integration test for generator lifecycle resource management. Specifically, we want to check if there are "dangling" GPU procs after the `Generator` shutdown as these tend to be running after the main proc exits. 

Interestingly, there ARE dangling CPU procs, which are eventually cleaned up once the test main proc exits. From the logging, there are 10 in total and 8 of them came from the weight fetcher procs.  D90185863 fixes the weight fetcher proc cleanup. But there are still 2 procs dangling -- we can reproduce the problem in P2106216182 using only monarch primitives.


## Test Plan
Run `pytest tests/integration_tests/test_generator_lifecycle.py -v -s` in vllm 0.10.0

```
[After Launch] Child processes: 15
[After Launch] GPU processes: 2
Health loop stopped gracefully.
/home/jiyue/.conda/envs/forge-b/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
/home/jiyue/.conda/envs/forge-b/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
[rank1]:[W106 10:09:39.436251217 TCPStore.cpp:125] [c10d] recvValue failed on SocketImpl(fd=108, addr=[devgpu004.rva5.facebook.com]:55882, remote=[devgpu004.rva5.facebook.com]:62117): Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
Exception raised from recvBytes at /pytorch/torch/csrc/distributed/c10d/Utils.hpp:697 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fca7015db80 in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x5ffd531 (0x7fc8a11fd531 in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #2: <unknown function> + 0x5ffe92d (0x7fc8a11fe92d in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #3: <unknown function> + 0x5fff4da (0x7fc8a11ff4da in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #4: c10d::TCPStore::check(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) + 0x31e (0x7fc8a11fa1fe in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #5: c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop() + 0x3c8 (0x7fc85fc546b8 in /home/jiyue/.conda/envs/forge-b/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #6: <unknown function> + 0xdf0e6 (0x7fc8f26f70e6 in /home/jiyue/.conda/envs/forge-b/bin/../lib/libstdc++.so.6)
frame #7: <unknown function> + 0x8b2fa (0x7fcf0008b2fa in /lib64/libc.so.6)
frame #8: <unknown function> + 0x110400 (0x7fcf00110400 in /lib64/libc.so.6)

[rank1]:[W106 10:09:39.440484501 ProcessGroupNCCL.cpp:1771] [PG ID 0 PG GUID 0 Rank 1] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
/home/jiyue/.conda/envs/forge-b/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
[actor=<root>] Error stopping proc_mesh for replica 0: _fetcher_procs
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
INFO 01-06 10:09:42 [__init__.py:235] [actor=<root>] Automatically detected platform cuda.
[After Shutdown] Child processes: 10
[After Shutdown] GPU processes: 0

⚠️  Dangling child processes detected:
  - PID 2497266 (PPID 2489382): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2497699 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2513498 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2513926 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2514332 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2515114 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2515579 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2516103 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main
  - PID 2516599 (PPID 2497266): python3.12 (sleeping)
    CMD: /home/jiyue/.conda/envs/forge-b/bin/python3.12 -m monarch._src.actor.bootstrap_main

Total: 9 dangling processes after shutdown (baseline: 0).This seems to be benigh as they'll be cleaned up when the parent process exits. See P2106216182 for repro with just monarch primitives.
✅ No dangling GPU processes detected
Health loop stopped gracefully.
[actor=<root>] Error stopping proc_mesh for replica 0: Endpoint call Generator.stop() failed, Actor unix:QSjWGfuvrG2cr47s2Eud8VLb,anon_0-1BnpLh57hFLm,Generator-1fbweHpcNuk8[0] exited because of the following reason: <PyActorSupervisionEvent: The actor <root>.<abc.Generator Generator{'procs': 0/1}> and all its descendants have failed.
This occurred because the actor itself failed.
The error was:
 stopped>
PASSED

```

Reviewed By: felipemello1, allenwang28

Differential Revision: D90067503


