### PR TITLE
[BUG FIX] add ref ckpt to config

### DIFF
--- a/apps/grpo/llama3_8b.yaml
+++ b/apps/grpo/llama3_8b.yaml
@@ -110,6 +110,7 @@ ref_model:
     context_parallel_degree: 1
     expert_parallel_degree: 1
   checkpoint:
+    enable: true
     initial_load_path: hf://${model}
     initial_load_in_hf: true
 

--- a/apps/grpo/qwen3_8b.yaml
+++ b/apps/grpo/qwen3_8b.yaml
@@ -110,6 +110,7 @@ ref_model:
     context_parallel_degree: 1
     expert_parallel_degree: 1
   checkpoint:
+    enable: true
     initial_load_path: hf://${model}
     initial_load_in_hf: true
 


### PR DESCRIPTION
configs were missing loading from ckpt for reference model. Now they follow the same as qwen 1.7b.