### PR TITLE
Update torchstore branch used in dependencies

### DIFF
--- a/assets/versions.sh
+++ b/assets/versions.sh
@@ -10,4 +10,4 @@
 # Stable versions of upstream libraries for OSS repo
 PYTORCH_VERSION="2.9.0"
 VLLM_VERSION="v0.10.0"
-TORCHSTORE_BRANCH="no-monarch-2025.12.17"
+TORCHSTORE_BRANCH="no-monarch-2026.01.05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ url = "https://download.pytorch.org/whl/preview/forge"
 torch = { index = "pytorch-cu128" }
 vllm = { index = "vllm-forge" }
 # Issue 656: switch to ping torchstore nightly
-torchstore = { git = "https://github.com/meta-pytorch/torchstore.git", branch = "no-monarch-2025.12.17" }
+torchstore = { git = "https://github.com/meta-pytorch/torchstore.git", branch = "no-monarch-2026.01.05" }
 
 [tool.uv]
 # TODO: revert to stricter default uv strategy


### PR DESCRIPTION
Summary:
Updating the torchstore branch to get a recent fix on torchstore main: https://github.com/meta-pytorch/torchstore/pull/88

this is the new torchstore branch we are using: https://github.com/meta-pytorch/torchstore/compare/main...no-monarch-2026.01.05

Differential Revision: D90139318


