### PR TITLE
Remove call to configure transport in SlurmLauncher

### DIFF
--- a/src/forge/controller/launcher.py
+++ b/src/forge/controller/launcher.py
@@ -11,8 +11,6 @@ import logging
 
 from forge.controller.base import BaseLauncher
 from forge.types import Launcher, LauncherConfig
-from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch.actor import ProcMesh
 from monarch.job import JobState, JobTrait, SlurmJob
 
@@ -67,11 +65,6 @@ class Slurmlauncher(BaseLauncher):
         Returns:
             A tuple of (job, job_state) containing the SlurmJob handle and its state.
         """
-        # HostMesh currently requires explicit configuration
-        # of the underlying transport from client to mesh.
-        # This can be removed in the future once this has been removed.
-        configure(default_transport=ChannelTransport.TcpWithHostname)
-
         # Collect all mesh requirements from config
         meshes = get_meshes_from_config(self.cfg)
 


### PR DESCRIPTION
## Description
nit, now that we are using the SlurmJob API from Monarch, this is handled for us here:

https://github.com/meta-pytorch/monarch/blob/dabde6fe3670e3efb37bd2b906963f93ee034776/python/monarch/_src/job/slurm.py#L78

## Test plan
```
python -m apps.grpo.main --config experimental/slurm/qwen3_8b.yaml
```