### PR TITLE
Remove Quick Start section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,6 @@ After install, you can run the following command and should see output confirmin
 python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml
 ```
 
-## Quick Start
-
-To run SFT on a Llama3 8B model, run
-
-```bash
-python -m apps.sft.main --config apps/sft/llama3_8b.yaml
-```
-
 ### Citation
 
 ## License


### PR DESCRIPTION
## Description
We already have a "quick start" command in the section above, with a GRPO command. Let's remove the SFT command, as GRPO should be the main entry point.

## Test plan
N/A