### PR TITLE
Upgrade pre-commit config to Python 3.12

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: 'build'
 
 default_language_version:
-    python: python3
+    python: python3.12
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Differential Revision: D90989293

Lint jobs are currently [failing](https://github.com/meta-pytorch/torchforge/actions/runs/21143567102/job/60803498883?pr=715) on all PRs with:
```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo7h_ul9_a/py_env-python3/bin/nbdev_clean", line 3, in <module>
    from nbdev.clean import nbdev_clean
  File "/home/runner/.cache/pre-commit/repo7h_ul9_a/py_env-python3/lib/python3.10/site-packages/nbdev/__init__.py", line 3, in <module>
    from .doclinks import nbdev_export
  File "/home/runner/.cache/pre-commit/repo7h_ul9_a/py_env-python3/lib/python3.10/site-packages/nbdev/doclinks.py", line 9, in <module>
    from .config import *
  File "/home/runner/.cache/pre-commit/repo7h_ul9_a/py_env-python3/lib/python3.10/site-packages/nbdev/config.py", line 11, in <module>
    from fastcore.docments import *
  File "/home/runner/.cache/pre-commit/repo7h_ul9_a/py_env-python3/lib/python3.10/site-packages/fastcore/docments.py", line 359
    sig_str = f"def {get_name(self.obj)}(\n    {'\n    '.join(lines)}\n{self._ret_str}"
                                                                                       ^
SyntaxError: f-string expression part cannot include a backslash
```

Using Python 3.12 fixes it.


