### PR TITLE
add tracer in v1 to log generator perf metrics

### DIFF
--- a/src/forge/actors/vllm/v1/forge_executor.py
+++ b/src/forge/actors/vllm/v1/forge_executor.py
@@ -31,6 +31,7 @@ from typing import Optional
 import cloudpickle
 from forge.actors._torchstore_utils import extract_param_name, get_param_prefix
 from forge.actors.vllm.v1.monarch_executor import MonarchExecutor, WorkerWrapper
+from forge.observability.perf_tracker import trace
 from monarch.actor import endpoint
 from torchstore.client import LocalClient
 
@@ -57,6 +58,11 @@ class ForgeWorkerWrapper(WorkerWrapper):
         self._torchstore_client = None  # Reset cached client
 
     @endpoint
+    @trace(
+        prefix="generator_perf/update_weights/generator_worker_update",
+        track_memory=False,
+        timer="gpu",
+    )
     def update_weights(self, version: int) -> int:
         """Load weights directly from torchstore.
 


### PR DESCRIPTION
Summary:
## tl;dr
Add tracer in v1 to log perf metrics to wandb 

## V0 vs V1 Metrics Parity Comparison

| Category | v0 Metric | v1 Metric | Parity |
|----------|-----------|-----------|--------|
| **Generate - Request Count** | `generator/generate/count_requests` (SUM) | `generator/generate/count_requests` (SUM) | ✅ Same |
| **Generate - Completion Count** | `generator/generate/count_sequences_completed` (SUM) | `generator/generate/count_sequences_completed` (SUM) | ✅ Same |
| **Generate - E2E Timing** | `generator_perf/generate/*` (Tracer, GPU) | `generator_perf/generate/*` (Tracer, GPU) | ✅ Same |
| **Update - Pending Requests** | `generator_perf/update_weights/sum_pending_gen_requests` (SUM) | N/A - AsyncLLM handles internally | ⚠️ Skip (by design) |
| **Update - Wait for Generation** | `generator_perf/update_weights/avg_waiting_for_generation_duration_s` (MEAN) | `generator_perf/update_weights/pause_generation_duration_s` (MEAN) | ✅ Equivalent - renamed for clarity |
| **Update - Fetch Weights** | `generator_perf/update_weights/wait_fetch_weights` (MEAN) | `generator_perf/update_weights/worker_load_weights_duration_s` (MEAN) | ✅ Equivalent - renamed for clarity |
| **Worker - Update Timing** | `generator_perf/update_weights/generator_worker_update/*` (trace, GPU) | `generator_perf/update_weights/generator_worker_update/*` (trace, GPU) | ✅ Same |

## Test Plan

Main GRPO app: `python -m apps.grpo.main --config apps/grpo/qwen3_1_7b.yaml`

```
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run drawn-waterfall-686
wandb: ⭐️ View project at https://meta.wandb.io/jiyue/grpo-training
wandb: 🚀 View run at https://meta.wandb.io/jiyue/grpo-training/runs/6pltx38p
wandb: Detected [openai] in use.
....
rvability.metric_actors.GlobalLoggingActor global_logger>] === [global_reduce] - METRICS STEP 1 ===
  ...
  generator/generate/count_requests: 13.0
  generator/generate/count_sequences_completed: 96.0
  generator_perf/generate/total_duration_avg_s: 3.6518315022786463
  generator_perf/generate/total_duration_max_s: 9.2080615234375
  generator_perf/update_weights/pause_generation_duration_s: 2.8634108749683946
  generator_perf/update_weights/resume_generation_duration_s: 1.918897032737732e-05
  generator_perf/update_weights/worker_load_weights_duration_s: 3.506648204056546
  ...
```


Make sure integration tests that do not initialize the tracer still works 
`pytest tests/integration_tests/test_generator_lifecycle.py -v -s`


## Next Steps
[ ] implement the prefetch logic & shared memory
[-] Add metric similar to generator v0
[ ] Perf/Throughput testing compared to generator v0

Differential Revision: D91038187


