### PR TITLE
prefetch weights while waiting for pending requests to complete

### DIFF
--- a/benchmarks/generator/weight_sync.py
+++ b/benchmarks/generator/weight_sync.py
@@ -1,0 +1,331 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Weight sync benchmark for torchforge generators.
+
+Measures the time for weight synchronization between trainer and generator,
+with and without shared memory prefetching enabled.
+
+Example usage:
+    # Basic benchmark (no prefetch)
+    python -m benchmarks.generator.weight_sync --config apps/grpo/qwen3_8b.yaml
+
+    # With prefetch enabled
+    python -m benchmarks.generator.weight_sync \
+        --config apps/grpo/qwen3_8b.yaml \
+        benchmark.prefetch_enabled=true \
+        benchmark.n_fetcher_procs=4 \
+        benchmark.iterations=5
+"""
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+
+import torch
+import torchstore as ts
+from forge.actors.generator import Generator
+from forge.actors.trainer import TitanTrainer
+from forge.controller.provisioner import init_provisioner, shutdown
+from forge.controller.service.service import uuid
+from forge.types import LauncherConfig, ProvisionerConfig
+from forge.util.config import parse, resolve_hf_hub_paths
+from monarch.actor import endpoint
+from omegaconf import DictConfig
+
+os.environ.setdefault("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT_SECS", "600")
+os.environ.setdefault("HYPERACTOR_CODE_MAX_FRAME_LENGTH", "1073741824")
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class BenchmarkTitanTrainer(TitanTrainer):
+    """TitanTrainer with weight modification capabilities for benchmarking."""
+
+    @endpoint
+    async def modify_weights(self):
+        """Scale all model weights by a factor (simulates training step)."""
+        scale: float = 1.001
+        for model_part in self.engine.model_parts:
+            sd = model_part.state_dict()
+            for k in sd.keys():
+                if torch.is_floating_point(sd[k]):
+                    sd[k] *= scale
+
+    @endpoint
+    async def get_model_size_bytes(self) -> int:
+        """Get total model size in bytes across all model parts."""
+        total_bytes = 0
+        for model_part in self.engine.model_parts:
+            for param in model_part.parameters():
+                total_bytes += param.numel() * param.element_size()
+        return total_bytes
+
+
+@dataclass
+class WeightSyncMetrics:
+    """Metrics from a single weight sync operation."""
+
+    version: int
+    total_time_s: float
+    push_time_s: float
+    update_time_s: float
+    prefetch_enabled: bool
+
+
+@dataclass
+class BenchmarkResults:
+    """Aggregated benchmark results."""
+
+    model: str
+    iterations: int
+    prefetch_enabled: bool
+    n_fetcher_procs: int
+    model_size_bytes: int = 0
+    metrics: list[WeightSyncMetrics] = field(default_factory=list)
+
+    @property
+    def model_size_gb(self) -> float:
+        return self.model_size_bytes / (1024**3)
+
+    @property
+    def avg_total_time_s(self) -> float:
+        if not self.metrics:
+            return 0.0
+        return sum(m.total_time_s for m in self.metrics) / len(self.metrics)
+
+    @property
+    def avg_push_time_s(self) -> float:
+        if not self.metrics:
+            return 0.0
+        return sum(m.push_time_s for m in self.metrics) / len(self.metrics)
+
+    @property
+    def avg_update_time_s(self) -> float:
+        if not self.metrics:
+            return 0.0
+        return sum(m.update_time_s for m in self.metrics) / len(self.metrics)
+
+    @property
+    def push_throughput_gb_s(self) -> float:
+        if self.avg_push_time_s <= 0 or self.model_size_bytes <= 0:
+            return 0.0
+        return self.model_size_gb / self.avg_push_time_s
+
+    @property
+    def update_throughput_gb_s(self) -> float:
+        if self.avg_update_time_s <= 0 or self.model_size_bytes <= 0:
+            return 0.0
+        return self.model_size_gb / self.avg_update_time_s
+
+
+def print_results(results: BenchmarkResults):
+    """Print benchmark results."""
+    print("\n" + "=" * 80)
+    print("WEIGHT SYNC BENCHMARK RESULTS")
+    print("=" * 80)
+    print(f"Model: {results.model}")
+    print(f"Model size: {results.model_size_gb:.2f} GB")
+    print(f"Iterations: {results.iterations}")
+    print(f"Prefetch enabled: {results.prefetch_enabled}")
+    if results.prefetch_enabled:
+        print(f"Fetcher procs: {results.n_fetcher_procs}")
+    print("-" * 80)
+    print(f"{'Metric':<30} {'Time (s)':<15} {'Throughput (GB/s)':<20}")
+    print("-" * 80)
+    print(
+        f"{'Avg push_weights':<30} {results.avg_push_time_s:>12.3f} s "
+        f"{results.push_throughput_gb_s:>12.2f} GB/s"
+    )
+    print(
+        f"{'Avg update_weights':<30} {results.avg_update_time_s:>12.3f} s "
+        f"{results.update_throughput_gb_s:>12.2f} GB/s"
+    )
+    print(f"{'Avg total (push + update)':<30} {results.avg_total_time_s:>12.3f} s")
+    print("=" * 80 + "\n")
+
+
+async def run_weight_sync_benchmark(
+    cfg: DictConfig,
+    iterations: int,
+    prefetch_enabled: bool,
+    n_fetcher_procs: int,
+    warmup_iterations: int,
+) -> BenchmarkResults:
+    """Run weight sync benchmark with knobs to enable prefetch, fetcher procs, etc.
+
+    Args:
+        cfg: TorchForge config from YAML
+        iterations: Number of weight sync iterations to benchmark
+        prefetch_enabled: Whether to enable shared memory prefetching
+        n_fetcher_procs: Number of fetcher processes (when prefetch_enabled=True)
+        warmup_iterations: Number of warmup iterations before timing
+
+    Returns:
+        BenchmarkResults with timing metrics
+    """
+    model_name = cfg.generator.engine_args.get("model", "unknown")
+
+    generator_cfg = cfg.generator.copy()
+    if prefetch_enabled:
+        generator_cfg.prefetch_weights_to_shm = True
+        generator_cfg.n_fetcher_procs = n_fetcher_procs
+    else:
+        generator_cfg.prefetch_weights_to_shm = False
+        generator_cfg.n_fetcher_procs = 0
+
+    if cfg.get("provisioner", None) is not None:
+        provisioner = await init_provisioner(
+            ProvisionerConfig(launcher_config=LauncherConfig(**cfg.provisioner))
+        )
+    else:
+        provisioner = await init_provisioner()
+
+    services_generator_cfg = cfg.services.generator.copy()
+    services_generator_cfg.num_replicas = 1
+
+    logger.info("Spawning Generator and Trainer...")
+    generator, trainer = await asyncio.gather(
+        Generator.options(**services_generator_cfg).as_service(**generator_cfg),
+        BenchmarkTitanTrainer.options(**cfg.actors.trainer).as_actor(**cfg.trainer),
+    )
+    logger.info("Generator and Trainer spawned.")
+
+    trainer_num_procs = cfg.actors.trainer["procs"]
+    trainer_host_mesh_name = cfg.actors.trainer["mesh_name"]
+    trainer_hosts = await provisioner.get_host_mesh(trainer_host_mesh_name)
+    # same as the main grpo app.
+    await ts.initialize(
+        mesh=trainer_hosts.spawn_procs(per_host={"procs": trainer_num_procs}),
+        strategy=ts.LocalRankStrategy(),
+    )
+    logger.info("Torchstore initialized with LocalRankStrategy")
+
+    if warmup_iterations > 0:
+        logger.info(f"Running {warmup_iterations} warmup iteration(s)...")
+        for i in range(warmup_iterations):
+            v = uuid.uuid4().int
+            await trainer.push_weights.call(policy_version=v)
+            await generator.update_weights.fanout(version=v)
+            await trainer.modify_weights.call()
+        logger.info("Warmup complete.")
+
+    # Get model size for throughput calculation
+    # With DTensor/TP, each rank's param.numel() returns global size, not shard size
+    # So just take one rank's value
+    model_size_result = await trainer.get_model_size_bytes.call()
+    _, model_size_bytes = next(iter(model_size_result.items()))
+    model_size_gb = model_size_bytes / (1024**3)
+    logger.info(f"Model size: {model_size_gb:.2f} GB")
+
+    logger.info(f"Running {iterations} timed iteration(s)...")
+    metrics: list[WeightSyncMetrics] = []
+
+    # Generate a test prompt for in-flight requests
+    test_prompt = "What is the capital of France? Please explain in detail."
+
+    for i in range(iterations):
+        v = uuid.uuid4().int
+
+        # Modify weights to simulate training
+        await trainer.modify_weights.call()
+
+        # Time push_weights
+        push_start = time.perf_counter()
+        await trainer.push_weights.call(policy_version=v)
+        push_end = time.perf_counter()
+        push_time_s = push_end - push_start
+
+        # Simulate in-flight requests that pause_generation must wait for
+        num_inflight = 4
+        generation_tasks = [
+            asyncio.create_task(generator.generate.route(test_prompt))
+            for _ in range(num_inflight)
+        ]
+        # Give generation a moment to start
+        await asyncio.sleep(0.1)
+
+        # Time update_weights (includes pause_generation waiting for in-flight)
+        update_start = time.perf_counter()
+        await generator.update_weights.fanout(version=v)
+        update_end = time.perf_counter()
+        update_time_s = update_end - update_start
+
+        # Wait for generation to complete (after weight update)
+        await asyncio.gather(*generation_tasks)
+
+        total_time_s = push_time_s + update_time_s
+
+        metrics.append(
+            WeightSyncMetrics(
+                version=v,
+                total_time_s=total_time_s,
+                push_time_s=push_time_s,
+                update_time_s=update_time_s,
+                prefetch_enabled=prefetch_enabled,
+            )
+        )
+
+        logger.info(
+            f"Iteration {i + 1}/{iterations}: push={push_time_s:.3f}s, "
+            f"update={update_time_s:.3f}s, total={total_time_s:.3f}s"
+        )
+
+    logger.info("Cleaning up...")
+    await trainer.cleanup.call()
+    await generator.shutdown()
+    await BenchmarkTitanTrainer.shutdown(trainer)
+    await ts.shutdown()
+
+    return BenchmarkResults(
+        model=model_name,
+        iterations=iterations,
+        prefetch_enabled=prefetch_enabled,
+        n_fetcher_procs=n_fetcher_procs if prefetch_enabled else 0,
+        model_size_bytes=model_size_bytes,
+        metrics=metrics,
+    )
+
+
+@parse
+def recipe_main(cfg: DictConfig = None) -> None:  # type: ignore[assignment]
+    """Main entry point for weight sync benchmark.
+
+    Args:
+        cfg: Config loaded from YAML file via @parse decorator.
+             Benchmark parameters can be specified via key=value overrides:
+             benchmark.iterations=5
+             benchmark.prefetch_enabled=true
+             benchmark.n_fetcher_procs=4
+             benchmark.warmup_iterations=1
+    """
+    cfg = resolve_hf_hub_paths(cfg)
+
+    benchmark_cfg = cfg.get("benchmark", {})
+    iterations = benchmark_cfg.get("iterations", 3)
+    prefetch_enabled = benchmark_cfg.get("prefetch_enabled", False)
+    n_fetcher_procs = benchmark_cfg.get("n_fetcher_procs", 8)
+    warmup_iterations = benchmark_cfg.get("warmup_iterations", 1)
+
+    results = asyncio.run(
+        run_weight_sync_benchmark(
+            cfg=cfg,
+            iterations=iterations,
+            prefetch_enabled=prefetch_enabled,
+            n_fetcher_procs=n_fetcher_procs,
+            warmup_iterations=warmup_iterations,
+        )
+    )
+    print_results(results)
+
+    asyncio.run(shutdown())
+
+
+if __name__ == "__main__":
+    recipe_main()

--- a/src/forge/actors/vllm/v1/generator.py
+++ b/src/forge/actors/vllm/v1/generator.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 import os
@@ -13,10 +14,17 @@ import time
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from multiprocessing import resource_tracker
 from typing import Any, Optional
 
 import cloudpickle
 import torch
+import torchstore as ts
+from forge.actors._torchstore_utils import (
+    extract_param_name,
+    get_param_key,
+    get_param_prefix,
+)
 from forge.controller import ForgeActor
 from forge.controller.provisioner import _get_provisioner
 from forge.data_models.completion import Completion
@@ -25,7 +33,8 @@ from forge.env import FORGE_DISABLE_METRICS
 from forge.observability.metric_actors import get_or_create_metric_logger
 from forge.observability.metrics import record_metric, Reduce
 from forge.observability.perf_tracker import Tracer
-from monarch.actor import endpoint, this_host
+from forge.util._shared_tensor import SharedTensor, SharedTensorHandle
+from monarch.actor import endpoint, ProcMesh, this_host
 from torchstore.api import _controller as get_torchstore_controller
 from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.llm import UsageContext
@@ -50,6 +59,11 @@ class Generator(ForgeActor):
     Args:
         engine_args: vLLM EngineArgs for model configuration. Can be EngineArgs or dict.
         sampling_params: Default SamplingParams for generation. Can be SamplingParams or dict.
+        prefetch_weights_to_shm: Whether to prefetch weights to shared memory for faster
+            weight updates. When enabled, weight fetchers download weights in parallel
+            to shared memory while generation is still running. Defaults to True.
+        n_fetcher_procs: Number of fetcher processes for parallel weight downloading.
+            Only used when prefetch_weights_to_shm is True. Defaults to 8.
 
     Example:
         >>> generator = await Generator.options(procs=1, with_gpus=True).as_service(
@@ -62,12 +76,16 @@ class Generator(ForgeActor):
 
     engine_args: EngineArgs | Mapping = field(default_factory=EngineArgs)
     sampling_params: SamplingParams | Mapping = field(default_factory=SamplingParams)
+    prefetch_weights_to_shm: bool = True
+    n_fetcher_procs: int = 8
 
     def __post_init__(self):
         super().__init__()
         self.llm: Optional[AsyncLLM] = None
         self.generator_version: int = 0
         self.workers: Any = None  # Workers ActorMesh, registered by MonarchExecutor
+        self.fetcher_procs: Optional[ProcMesh] = None  # Fetcher proc mesh
+        self.weight_fetchers: Any = None  # Weight fetcher ActorMesh
 
         if isinstance(self.engine_args, Mapping):
             self.engine_args = EngineArgs(**self.engine_args)
@@ -223,6 +241,14 @@ class Generator(ForgeActor):
         self.vllm_config.parallel_config.distributed_executor_backend = (
             "forge.actors.vllm.v1.forge_executor.ForgeMonarchExecutor"
         )
+
+        # Set up prefetching configuration via additional_config
+        # There does not seem to be  a real difference between pass by env var or via self.vllm_config
+        if self.prefetch_weights_to_shm:
+            self.vllm_config.additional_config["n_fetcher_procs"] = self.n_fetcher_procs
+        else:
+            self.vllm_config.additional_config["n_fetcher_procs"] = 0
+
         from vllm.v1.executor.abstract import Executor
 
         try:
@@ -246,6 +272,70 @@ class Generator(ForgeActor):
                 "MonarchExecutor may have failed to register workers."
             )
         logger.info(f"Retrieved workers from registry: {self.workers}")
+
+        if self.prefetch_weights_to_shm:
+            self._spawn_fetchers()
+
+    def _spawn_fetchers(self):
+        """Spawn weight fetchers that prefetch weights from torchstore to shared memory.
+
+        This assumes the generator is on the same host as the worker and only works for
+        single host generators.
+        """
+        fetcher_procs = this_host().spawn_procs(
+            per_host={"procs": self.n_fetcher_procs}
+        )
+        self.fetcher_procs = fetcher_procs
+        self.weight_fetchers = fetcher_procs.spawn("weight_fetcher", _WeightFetcher)
+        logger.info(
+            f"[Generator] Spawned {self.n_fetcher_procs} weight fetchers: {self.weight_fetchers}"
+        )
+
+    async def _fetch_weights(
+        self,
+        version: int,
+    ) -> dict[str, SharedTensorHandle]:
+        """Fetch weights from torchstore and return a dict of {name: SharedTensorHandle}.
+
+        Coordinates parallel weight fetching across fetcher processes using round-robin
+        distribution of parameters.
+
+        Args:
+            version: Policy version to fetch
+
+        Returns:
+            Dict mapping param names to SharedTensorHandle objects
+        """
+        prefix = get_param_prefix(version)
+        matching_keys = await ts.keys(prefix)
+        hf_param_names = [extract_param_name(key) for key in matching_keys]
+
+        n_fetchers = self.weight_fetchers.size()
+
+        def split_keys(keys):
+            return [keys[i::n_fetchers] for i in range(n_fetchers)]
+
+        futures = []
+        for i, names in enumerate(split_keys(hf_param_names)):
+            fut = self.weight_fetchers.slice(procs=i).fetch.call_one(
+                version=version, param_names=names
+            )
+            futures.append(fut)
+
+        sub_state_dicts = [await fut for fut in futures]
+
+        state_dict = {}
+        for sd in sub_state_dicts:
+            state_dict.update(sd)
+
+        logger.info(
+            f"[Generator] Fetched {len(state_dict)} weights for v{version} to shared memory"
+        )
+        return state_dict
+
+    async def _drop_shared_memory(self, state_dict: dict[str, SharedTensorHandle]):
+        for handle in state_dict.values():
+            handle.drop()
 
     @endpoint
     async def generate(
@@ -305,6 +395,14 @@ class Generator(ForgeActor):
         This method is idempotent and can be called multiple times safely.
         Note: Remote worker cleanup happens in shutdown() which has access to the proxy.
         """
+        if self.fetcher_procs is not None:
+            try:
+                await self.fetcher_procs.stop()
+                logger.info("Stopped fetcher procs")
+            except Exception as e:
+                logger.warning(f"Error stopping fetcher procs: {e}")
+            self.fetcher_procs = None
+
         if self.llm is not None:
             logger.info("Stopping AsyncLLM")
             self.llm.shutdown()
@@ -344,9 +442,14 @@ class Generator(ForgeActor):
         """Update weights on the generator from torchstore.
 
         This method:
-        1. Pauses generation and waits for in-flight requests to complete
-        2. Updates weights on workers from torchstore
-        3. Resumes generation
+        1. Optionally starts prefetching weights to shared memory (overlaps with pause)
+        2. Pauses generation and waits for in-flight requests to complete
+        3. Updates weights on workers (from shared memory if prefetched, else from torchstore)
+        4. Resumes generation
+
+        When prefetch_weights_to_shm is enabled, weight fetching is started as an async task
+        BEFORE pause_generation(), overlapping I/O with in-flight request completion.
+        This reduces the time generation is paused.
 
         Note: This is NOT the standard vLLM weight update approach. vLLM typically
         uses `collective_rpc` on EngineClient, which internally routes calls to
@@ -366,6 +469,12 @@ class Generator(ForgeActor):
 
         logger.info(f"Starting weight update to v{version}")
 
+        # Start prefetching weights to shared memory (overlaps with pause)
+        fetch_task = None
+        if self.prefetch_weights_to_shm:
+            logger.info(f"[Generator] Starting prefetch for v{version}")
+            fetch_task = asyncio.create_task(self._fetch_weights(version or 0))
+
         pause_start = time.perf_counter()
         await self.llm.pause_generation(
             wait_for_inflight_requests=True, clear_cache=True
@@ -379,7 +488,22 @@ class Generator(ForgeActor):
 
         try:
             load_start = time.perf_counter()
-            await self.workers.update_weights.call(version)
+
+            if fetch_task is not None:
+                wait_fetch_start = time.perf_counter()
+                fetched_weights = await fetch_task
+                wait_fetch_duration = time.perf_counter() - wait_fetch_start
+                record_metric(
+                    "generator_perf/update_weights/wait_fetch_weights_s",
+                    wait_fetch_duration,
+                    Reduce.MEAN,
+                )
+                await self.workers.apply_prefetched_weights.call(fetched_weights)
+                await self._drop_shared_memory(fetched_weights)
+            else:
+                # Direct fetch from torchstore
+                await self.workers.update_weights.call(version=version)
+
             load_duration = time.perf_counter() - load_start
             record_metric(
                 "generator_perf/update_weights/worker_load_weights_duration_s",
@@ -387,7 +511,6 @@ class Generator(ForgeActor):
                 Reduce.MEAN,
             )
             self.generator_version = version
-            logger.info(f"Updated weights from torchstore v{version}")
         finally:
             await self.llm.resume_generation()
         logger.info(f"Weight update complete, now v{version}")
@@ -438,3 +561,44 @@ class Generator(ForgeActor):
             completions.append(completion)
 
         return completions
+
+
+class _WeightFetcher(ForgeActor):
+    """Fetches weights from torchstore and loads them into shared memory.
+
+    Spawned by Generator using this_host().spawn_procs() to ensure shared
+    memory IPC namespace is shared with workers. This is critical for POSIX
+    shared memory to be visible between fetchers and workers.
+    """
+
+    @endpoint
+    async def fetch(
+        self,
+        *,
+        version: int,
+        param_names: list[str],
+    ) -> dict[str, SharedTensorHandle]:
+        """Fetch weights from torchstore and load them into shared memory.
+
+        Args:
+            version: Policy version
+            param_names: List of parameter names to fetch
+
+        Returns:
+            Dict mapping param names to SharedTensorHandle objects
+        """
+
+        sd = {}
+        for name in param_names:
+            param_key = get_param_key(version, name)
+            param = await ts.get(param_key)
+            shared_tensor = SharedTensor(tensor=param)
+            handle = shared_tensor.get_handle()
+            # Unregister from resource tracker - Generator will handle cleanup via drop()
+            # Without this, the shared memory gets cleaned up when the fetcher process exits
+            resource_tracker.unregister(f"/{handle.shm_name}", "shared_memory")
+
+            sd[name] = handle
+            shared_tensor.close()  # Close fd but don't unlink (workers will use it)
+            del param  # Explicitly free the tensor after copying to shared memory
+        return sd


### PR DESCRIPTION
Summary:
Feature parity with v0: allow prefetching weights while waiting for the pending requests to finish.

## Test Plan 
Introduced a benchmark that simulates the on-going requests with actual weight sync logic.

Reference Group (V0)
```
================================================================================
WEIGHT SYNC BENCHMARK RESULTS
================================================================================
Model: Qwen/Qwen3-8B
Model size: 15.26 GB
Iterations: 3
Prefetch enabled: False
--------------------------------------------------------------------------------
Metric                         Time (s)        Throughput (GB/s)   
--------------------------------------------------------------------------------
Avg push_weights                      5.102 s         2.99 GB/s
Avg update_weights                   43.738 s         0.35 GB/s
Avg total (push + update)            48.840 s
================================================================================

================================================================================
WEIGHT SYNC BENCHMARK RESULTS
================================================================================
Model: Qwen/Qwen3-8B
Model size: 15.26 GB
Iterations: 3
Prefetch enabled: True
Fetcher procs: 8
--------------------------------------------------------------------------------
Metric                         Time (s)        Throughput (GB/s)   
--------------------------------------------------------------------------------
Avg push_weights                      5.208 s         2.93 GB/s
Avg update_weights                   29.602 s         0.52 GB/s
Avg total (push + update)            34.810 s
================================================================================

```

Test Group (V1)
```
================================================================================
WEIGHT SYNC BENCHMARK RESULTS
================================================================================
Model: Qwen/Qwen3-8B
Model size: 15.26 GB
Iterations: 3
Prefetch enabled: False
--------------------------------------------------------------------------------
Metric                         Time (s)        Throughput (GB/s)   
--------------------------------------------------------------------------------
Avg push_weights                      5.070 s         3.01 GB/s
Avg update_weights                   39.974 s         0.38 GB/s
Avg total (push + update)            45.044 s
================================================================================

================================================================================
WEIGHT SYNC BENCHMARK RESULTS
================================================================================
Model: Qwen/Qwen3-8B
Model size: 15.26 GB
Iterations: 3
Prefetch enabled: True
Fetcher procs: 8
--------------------------------------------------------------------------------
Metric                         Time (s)        Throughput (GB/s)   
--------------------------------------------------------------------------------
Avg push_weights                      5.055 s         3.02 GB/s
Avg update_weights                   28.730 s         0.53 GB/s
Avg total (push + update)            33.784 s
================================================================================
```


## Next Steps
[-] implement the prefetch logic & shared memory
[-] Add metric similar to generator v0
[ ] Perf/Throughput testing compared to generator v0

Differential Revision: D91092833


