### PR TITLE
Misc fixes to prepare for vllm v0.13.0 version bump

### DIFF
--- a/tests/unit_tests/test_generator_config.py
+++ b/tests/unit_tests/test_generator_config.py
@@ -45,7 +45,6 @@ class TestGeneratorConfig(unittest.TestCase):
         self.assertEqual(generator.engine_args.tensor_parallel_size, 1)
         self.assertEqual(generator.engine_args.pipeline_parallel_size, 1)
         self.assertFalse(generator.engine_args.enforce_eager)
-        self.assertTrue(generator.engine_args._is_v1_supported_oracle())
 
         # Sampling defaults
         self.assertEqual(generator.sampling_params.n, 1)
@@ -90,7 +89,6 @@ class TestGeneratorConfig(unittest.TestCase):
         self.assertEqual(generator.engine_args.gpu_memory_utilization, 0.1)
         self.assertEqual(generator.engine_args.max_model_len, 1024)
         self.assertTrue(generator.engine_args.enforce_eager)
-        self.assertTrue(generator.engine_args._is_v1_supported_oracle())
 
         self.assertEqual(generator.sampling_params.n, 2)
         self.assertEqual(generator.sampling_params.max_tokens, 32)
@@ -127,7 +125,6 @@ class TestGeneratorConfig(unittest.TestCase):
             self.assertEqual(generator.engine_args.tensor_parallel_size, 1)
             self.assertEqual(generator.engine_args.pipeline_parallel_size, 1)
             self.assertTrue(generator.engine_args.enforce_eager)
-            self.assertTrue(generator.engine_args._is_v1_supported_oracle())
 
             self.assertEqual(generator.sampling_params.n, 2)
             self.assertEqual(generator.sampling_params.max_tokens, 32)


### PR DESCRIPTION
- Remove _is_v1_supported_oracle() assertions from tests (method was removed in vllm v0.13.0)
- Update benchmarks/generator/throughput.py to show progress bar