### PR TITLE
[vllm] fix another test to prepare for vllm upgrade 

### DIFF
--- a/tests/unit_tests/test_generator_config.py
+++ b/tests/unit_tests/test_generator_config.py
@@ -48,7 +48,6 @@ class TestGeneratorConfig(unittest.TestCase):
 
         # Sampling defaults
         self.assertEqual(generator.sampling_params.n, 1)
-        self.assertFalse(generator.sampling_params.guided_decoding)
         self.assertEqual(generator.sampling_params.max_tokens, 16)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
The guided_decoding attribute was removed from SamplingParams in vllm v0.13.0. 