### PR TITLE
[FIX] Drop only the sample truncated instead of the entire group

### DIFF
--- a/apps/grpo/main.py
+++ b/apps/grpo/main.py
@@ -269,11 +269,11 @@ async def main(cfg: DictConfig):
             for episode, advantage in zip(episodes, advantages):
                 episode.advantage = advantage
 
-                # Skip truncated episodes - don't add to replay buffer
-                # TODO: investigate setting loss_mask=0 instead of dropping
+                # Zero out loss_mask for truncated episodes so they don't contribute to gradient
+                # TODO: evaluate if we should drop truncated episodes instead
                 if episode.completion.stop_reason == "length":
+                    episode.loss_mask = torch.zeros_like(episode.loss_mask)
                     num_truncated += 1
-                    continue
 
                 await replay_buffer.add.call_one(episode)
 


### PR DESCRIPTION
- [x] I have personally reviewed this PR and description before asking others to do so. It meets the quality bar I expect from others. I understand that if this PR is perceived as unverified AI-generated code, it will be closed without further explanation.
- [x] I have run tests and confirmed that this code works

---

## Description
- We want to drop a sample that is truncated, since we cannot properly compute rewards for it
- Previously we were dropping all episodes in a group if any episode was truncated
- This eventually caused the buffer to never have episodes available

Fix: instead of dropping all samples, we just set the adv of truncated samples to 0.
You may ask: why not just drop them?
Because if our bsz=8, and we drop 1, now we have only 7 samples, and the trainer may need to wait until the next batch to train on the previous one, but at this point, the replay buffer may evict older policies, we would have a mess

<img width="465" height="612" alt="image" src="https://github.com/user-attachments/assets/2f22cde9-431f-40cd-9024-15c43c4de3ff" />

## Test plan
<img width="1387" height="597" alt="image" src="https://github.com/user-attachments/assets/51b8fb52-53fa-4637-8671-2a9a74815ba2" />
<img width="462" height="282" alt="image" src="https://github.com/user-attachments/assets/657a3e57-8289-48a2-8824-1aaec5060056" />

