### PR TITLE
Fix pixi.toml: Remove references to deleted vllm requirements file

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -49,21 +49,6 @@ install-pytorch = """
     uv pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128
 """
 
-# CRITICAL: Install vLLM dependencies BEFORE installing vLLM itself
-install-vllm-reqs = """
-    uv pip install -r .github/packaging/vllm_reqs_12_8.txt
-"""
-
-install-vllm-deps = """
-    uv pip install six && \
-    uv pip install "setuptools<80"
-"""
-
-# Install vLLM after all dependencies are resolved
-install-vllm = """
-    uv pip install vllm --no-cache-dir --index-url https://download.pytorch.org/whl/preview/forge
-"""
-
 install-torchstore = """
     uv pip install "git+https://github.com/meta-pytorch/torchstore.git@no-monarch-2025.12.17"
 """
@@ -73,7 +58,7 @@ install-forge = """
 """
 
 # Full installation task - follows exact sequence from install.sh
-install = { depends-on = ["install-pytorch", "install-vllm-reqs", "install-vllm-deps", "install-vllm", "install-torchstore", "install-forge"] }
+install = { depends-on = ["install-pytorch", "install-torchstore", "install-forge"] }
 
 # Test installation task
 test-install = """


### PR DESCRIPTION
## Summary

- Removes obsolete `install-vllm-reqs`, `install-vllm-deps`, and `install-vllm` tasks from pixi.toml
- Updates the `install` task to remove dependencies on deleted tasks
- Fixes `pixi run install` which was failing with: `error: File not found: .github/packaging/vllm_reqs_12_8.txt`

## Context

PR #737 ([vllm] Upgrade vllm version to v0.13.0, commit cd9e295) deleted `.github/packaging/vllm_reqs_12_8.txt` because vllm is now specified as a regular dependency in `pyproject.toml`. However, `pixi.toml` was not updated in that PR, leaving stale references to the deleted file.

With this fix, vllm is installed as a transitive dependency of forge (via `install-forge` which runs `uv pip install -e ".[dev]"`), matching the behavior of `scripts/install.sh`.

## Test plan

- [x] Verified `pixi run install` completes successfully
- [x] Verified `pixi run test-install` shows PyTorch, vLLM, and forge all import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)