### PR TITLE
Update monarch import for torchmonarch 0.4.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "torch==2.9.0",
     "torchdata>=0.8.0",
     "torchtitan==0.2.0",
-    "torchmonarch==0.2.0",
+    "torchmonarch>=0.3.0",
     # Issue 656: switch to ping torchstore nightly
     "torchstore",
     "vllm>=0.13.0,<0.14.0",

--- a/src/forge/controller/provisioner.py
+++ b/src/forge/controller/provisioner.py
@@ -25,7 +25,7 @@ from monarch.actor import (
     shutdown_context,
     this_host,
 )
-from monarch.utils import setup_env_for_distributed
+from monarch.spmd import setup_torch_elastic_env_async as setup_env_for_distributed
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Replace removed monarch.utils.setup_env_for_distributed with monarch.spmd.setup_torch_elastic_env_async (same signature). Relax torchmonarch pin from ==0.2.0 to >=0.3.0.

Made-with: Cursor

- [ ] I have personally reviewed this PR and description before asking others to do so. It meets the quality bar I expect from others. I understand that if this PR is perceived as unverified AI-generated code, it will be closed without further explanation.
- [ ] I have run tests and confirmed that this code works

---

## Description

## Test plan
