### PR TITLE
improve: surface extra wandb.init kwargs in WandbBackend (#594)

### DIFF
--- a/src/forge/observability/metrics.py
+++ b/src/forge/observability/metrics.py
@@ -906,9 +906,24 @@ class WandbBackend(LoggerBackend):
         per_rank_share_run (bool, default False): For per-rank modes, whether to share run ID across ranks.
             If true, a single wandb run is created and all ranks log to it. Particularly useful for
             logging with no_reduce to capture time-based streams. Not recommended if reducing values.
-        **kwargs: Any argument accepted by wandb.init() (e.g., project, group, name, tags, notes, etc.)
+        **kwargs: Any argument accepted by wandb.init() (e.g., project, group, name, tags, notes,
+            entity, mode, dir, ...) is forwarded verbatim. Anything you place under
+            ``metric_logging.wandb:`` in your YAML config that isn't ``logging_mode`` or
+            ``per_rank_share_run`` lands in this **kwargs and reaches ``wandb.init`` unchanged.
 
-    Example:
+    YAML example:
+        metric_logging:
+          wandb:
+            logging_mode: global_reduce
+            project: my_project
+            group: exp_group
+            name: my_experiment
+            tags: ["rl", "v2"]
+            notes: "Testing new reward"
+            entity: my_team       # forwarded to wandb.init
+            mode: offline         # forwarded to wandb.init
+
+    Python example:
         WandbBackend(
             logging_mode=LoggingMode.PER_RANK_REDUCE,
             per_rank_share_run=False,
@@ -916,7 +931,7 @@ class WandbBackend(LoggerBackend):
             group="exp_group",
             name="my_experiment",
             tags=["rl", "v2"],
-            notes="Testing new reward"
+            notes="Testing new reward",
         )
     """
 
@@ -929,6 +944,12 @@ class WandbBackend(LoggerBackend):
         self.run = None
         self.process_name = None
         self._tables: dict[str, "wandb.Table"] = {}
+        if kwargs:
+            logger.info(
+                "WandbBackend: forwarding %d extra kwarg(s) to wandb.init: %s",
+                len(kwargs),
+                sorted(kwargs.keys()),
+            )
 
     async def init(
         self,

--- a/tests/unit_tests/observability/test_metrics.py
+++ b/tests/unit_tests/observability/test_metrics.py
@@ -346,6 +346,39 @@ class TestCriticalFixes:
         metadata = backend.get_metadata_for_secondary_ranks()
         assert metadata == {}  # Should be empty when no run
 
+    def test_wandb_backend_logs_extra_kwargs(self, caplog):
+        """Visibility check for #594: extra kwargs forwarded to wandb.init
+        should be surfaced at INFO so users see what the YAML actually sent."""
+        import logging as _logging
+
+        with caplog.at_level(_logging.INFO, logger="forge.observability.metrics"):
+            WandbBackend(
+                logging_mode=LoggingMode.GLOBAL_REDUCE,
+                project="p",
+                entity="my_team",
+                mode="offline",
+            )
+
+        forwarded_logs = [
+            r for r in caplog.records if "forwarding" in r.getMessage()
+        ]
+        assert forwarded_logs, "expected an INFO log listing forwarded wandb kwargs"
+        msg = forwarded_logs[0].getMessage()
+        for expected in ("project", "entity", "mode"):
+            assert expected in msg, f"kwarg {expected!r} not surfaced in log: {msg}"
+
+    def test_wandb_backend_no_log_when_no_extra_kwargs(self, caplog):
+        """No-op when only the named args are passed."""
+        import logging as _logging
+
+        with caplog.at_level(_logging.INFO, logger="forge.observability.metrics"):
+            WandbBackend(logging_mode=LoggingMode.GLOBAL_REDUCE)
+
+        forwarded_logs = [
+            r for r in caplog.records if "forwarding" in r.getMessage()
+        ]
+        assert not forwarded_logs, "should not log when no extra kwargs provided"
+
     @pytest.mark.asyncio
     async def test_console_backend(self):
         """Test ConsoleBackend basic operations."""


### PR DESCRIPTION
## Summary

Addresses #594.

Anything you place under `metric_logging.wandb:` in a YAML config that isn't `logging_mode` or `per_rank_share_run` is forwarded verbatim to `wandb.init` via `**kwargs`. This already works — it just isn't obvious, so a user can mistype `entity` or `mode` and silently get a different run than they expected.

This PR makes it obvious in two complementary ways:

1. **Docstring** — adds an explicit YAML example showing forwarded keys (`entity`, `mode`) alongside the named ones.
2. **Runtime** — emits one INFO log at `__init__` listing the extra kwargs being forwarded:
   ```
   WandbBackend: forwarding 3 extra kwarg(s) to wandb.init: ['entity', 'mode', 'project']
   ```

No behavior change for wandb itself; this is a visibility fix.

## Test plan

- [x] New `test_wandb_backend_logs_extra_kwargs` — verifies INFO log lists forwarded keys
- [x] New `test_wandb_backend_no_log_when_no_extra_kwargs` — verifies silence when only named args passed
- [x] Existing `test_wandb_backend_creation` still passes (no API changes)